### PR TITLE
fix: メッセージ投稿フォームが画面下部まで伸びるように修正

### DIFF
--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -96,9 +96,9 @@ export const NoteList: React.FC<NoteListProps> = ({
   };
 
   return (
-    <div className="flex flex-1 flex-col bg-background" data-testid="note-list">
+    <div className="flex flex-col h-full w-full bg-background" data-testid="note-list">
       {/* Header */}
-      <div className="flex h-14 items-center justify-between border-b border-border px-4">
+      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0">
         <div className="flex items-center gap-2">
           <Hash className="h-5 w-5 text-muted-foreground" />
           <h1 className="font-semibold text-foreground text-lg">notes</h1>
@@ -114,7 +114,7 @@ export const NoteList: React.FC<NoteListProps> = ({
       </div>
 
       {/* Search Bar */}
-      <div className="border-b border-border p-4">
+      <div className="border-b border-border p-4 flex-shrink-0">
         <div className="relative">
           <Search className="absolute top-2.5 left-3 h-4 w-4 text-muted-foreground" />
           <Input
@@ -316,7 +316,7 @@ export const NoteList: React.FC<NoteListProps> = ({
 
       {/* Note Editor at bottom */}
       {onCreateNote && (
-        <div className="border-t border-border p-4">
+        <div className="border-t border-border p-4 flex-shrink-0">
           <NoteEditor onSubmit={onCreateNote} placeholder="Message #notes" />
         </div>
       )}

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -108,11 +108,11 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
 
   return (
     <div
-      className="flex w-full flex-col border-l border-border bg-background"
+      className="flex w-full h-full flex-col bg-background"
       data-testid="thread-view"
     >
       {/* Header */}
-      <div className="flex h-14 items-center justify-between border-b border-border px-4">
+      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0">
         <h3 className="font-semibold text-foreground text-sm">Thread</h3>
         <Button size="icon" variant="ghost" className="h-8 w-8">
           <X className="h-4 w-4" />
@@ -120,7 +120,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
       </div>
 
       {/* Original Message */}
-      <div className="border-b border-border p-4">
+      <div className="border-b border-border p-4 flex-shrink-0">
         <div className="group relative space-y-2" data-testid="thread-node">
           <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
             <DropdownMenu>
@@ -416,7 +416,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
       </ScrollArea>
 
       {/* Reply Input */}
-      <div className="border-t border-border p-4" data-testid="thread-reply-input">
+      <div className="border-t border-border p-4 flex-shrink-0" data-testid="thread-reply-input">
         <div className="flex items-end gap-2">
           <div className="flex-1 rounded-lg border border-input bg-card">
             <Input

--- a/frontend/src/layouts/SplitView.tsx
+++ b/frontend/src/layouts/SplitView.tsx
@@ -171,12 +171,10 @@ export const SplitView: React.FC<SplitViewProps> = ({
       {/* Left Panel */}
       <div
         ref={leftPanelRef}
-        className="h-full overflow-hidden border-r border-border"
+        className="h-full overflow-hidden border-r border-border flex"
         style={{ width: `${splitPosition}%` }}
       >
-        <div className="w-full h-full overflow-auto">
-          {left}
-        </div>
+        {left}
       </div>
 
       {/* Divider */}
@@ -210,12 +208,10 @@ export const SplitView: React.FC<SplitViewProps> = ({
       {/* Right Panel */}
       <div
         ref={rightPanelRef}
-        className="h-full overflow-hidden"
+        className="h-full overflow-hidden flex"
         style={{ width: `${100 - splitPosition}%` }}
       >
-        <div className="w-full h-full overflow-auto">
-          {right}
-        </div>
+        {right}
       </div>
 
       {/* NOTE: Keyboard shortcuts hint */}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -86,7 +86,7 @@ export const NotesPage: React.FC = () => {
   const displayNotes = notesData?.pages.flatMap((page) => page.notes) || [];
 
   return (
-    <div className="notes-page">
+    <div className="h-full w-full">
       {/* NOTE: Split view layout */}
       <SplitView
         left={
@@ -101,7 +101,7 @@ export const NotesPage: React.FC = () => {
           />
         }
         right={
-          <div className="notes-page__right">
+          <div className="h-full w-full flex flex-col">
             {selectedNoteId && noteData?.note ? (
               <ThreadView
                 rootNote={noteData.note}
@@ -134,13 +134,15 @@ export const NotesPage: React.FC = () => {
                 }}
               />
             ) : noteLoading ? (
-              <div className="notes-page__loading">
-                <div className="spinner" />
-                <p>Loading thread...</p>
+              <div className="flex h-full items-center justify-center">
+                <div className="flex flex-col items-center gap-2">
+                  <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  <p className="text-muted-foreground text-sm">Loading thread...</p>
+                </div>
               </div>
             ) : (
-              <div className="notes-page__empty">
-                <p>Select a note to view its thread</p>
+              <div className="flex h-full items-center justify-center">
+                <p className="text-muted-foreground text-sm">Select a note to view its thread</p>
               </div>
             )}
           </div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -79,6 +79,10 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html, body, #root {
+    height: 100%;
+    overflow: hidden;
+  }
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans);


### PR DESCRIPTION
## Summary
メッセージ投稿フォームが画面下部まで伸びない問題を修正しました。

## Changes
- `globals.css`: `html`, `body`, `#root` に `height: 100%` と `overflow: hidden` を追加
- `NotesPage`: ルートコンテナに `h-full w-full` を追加
- `SplitView`: 左右パネルのレイアウトを簡素化し、flexレイアウトを適用
- `NoteList`: ヘッダー、検索バー、エディターに `flex-shrink-0` を追加し、ScrollAreaが残りのスペースを占有するように修正
- `ThreadView`: 同様にflexレイアウトを適用し、画面全体を使用するように修正

## Screenshots
![修正後](.vibe-images/fixed-layout-result.png)

## Test plan
- [x] 開発サーバーで動作確認
- [x] レイアウトが画面全体に表示されることを確認
- [x] メッセージ投稿フォームが画面下部に固定されることを確認
- [x] スクロールエリアが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)