### PR TITLE
fix: replace db.execute with Drizzle ORM queries for D1 compatibility

### DIFF
--- a/backend/src/db/types.d.ts
+++ b/backend/src/db/types.d.ts
@@ -9,16 +9,6 @@ export type BunDatabase = BunSQLiteDatabase<typeof schema>;
 // NOTE: D1 database type for Cloudflare Workers
 export type D1DrizzleDatabase = DrizzleD1Database<typeof schema>;
 
-// NOTE: Execute method return type for raw SQL queries
-export interface ExecuteResult {
-  rows: unknown[];
-}
-
-// NOTE: Common database interface with execute method for raw SQL
-// TODO: REMOVE
-export interface DatabaseWithExecute {
-  execute: (query: SQL) => Promise<ExecuteResult>;
-}
-
 // NOTE: Union type supporting both Bun SQLite (dev) and D1 (production)
-export type Database = (BunDatabase | D1DrizzleDatabase) & DatabaseWithExecute;
+// Both database types now use the same Drizzle ORM API
+export type Database = BunDatabase | D1DrizzleDatabase;

--- a/backend/src/models/note.schema.ts
+++ b/backend/src/models/note.schema.ts
@@ -17,3 +17,4 @@ export const notes = sqliteTable('notes', {
 
 export type Note = typeof notes.$inferSelect;
 export type NewNote = typeof notes.$inferInsert;
+export type NoteWithReplyCount = Note & { replyCount: number };

--- a/backend/src/repositories/search.repository.ts
+++ b/backend/src/repositories/search.repository.ts
@@ -1,6 +1,6 @@
 import { db } from '../db';
 import { notes } from '../models/note.schema';
-import { like, desc, asc, eq, and, or, sql, count } from 'drizzle-orm';
+import { like, desc } from 'drizzle-orm';
 import type { Note } from '../db';
 
 // NOTE: Repository for content search using advanced Drizzle ORM features
@@ -16,8 +16,7 @@ export class SearchRepository {
       .from(notes)
       .where(like(notes.content, likePattern))
       .orderBy(desc(notes.updatedAt))
-      .limit(limit)
-      .execute();
+      .limit(limit);
 
     return result;
   }


### PR DESCRIPTION
Replace raw SQL execution with standard Drizzle ORM queries to fix "db.execute is not a function" error in Cloudflare D1 environment.

Changes:
- Replace recursive CTE with breadth-first traversal in getThreadRecursive
- Remove .execute() call from searchByContent
- Remove DatabaseWithExecute type definition
- Clean up unused imports (sql, asc, eq, and, or, count)

This ensures compatibility across both Bun SQLite and Cloudflare D1 environments using only common Drizzle ORM APIs.