### PR TITLE
レスポンシブデザインの実装

### DIFF
--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -11,6 +11,7 @@ import {
   Link2,
   Edit,
   Pin,
+  ArrowLeft,
 } from 'lucide-react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
@@ -23,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { getRelativeTime } from '@/lib/utils';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import NoteEditor from './NoteEditor';
 
 interface ThreadViewProps {
@@ -32,6 +34,7 @@ interface ThreadViewProps {
   onEdit: (noteId: string, content: string) => Promise<void>;
   onDelete: (noteId: string) => Promise<void>;
   currentUserId?: string;
+  onClose?: () => void;
 }
 
 export const ThreadView: React.FC<ThreadViewProps> = ({
@@ -41,11 +44,13 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
   onEdit,
   onDelete,
   currentUserId: _currentUserId,
+  onClose,
 }) => {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState<string | null>(null);
   const [replyContent, setReplyContent] = useState('');
   const [expandedImages, setExpandedImages] = useState<Record<string, boolean>>({});
+  const isMobile = !useMediaQuery('(min-width: 1024px)');
 
   const copyLink = (noteId: string) => {
     navigator.clipboard.writeText(`${window.location.origin}/notes/${noteId}`);
@@ -107,16 +112,28 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
   }, [thread, rootNote.id]);
 
   return (
-    <div
-      className="flex w-full h-full flex-col bg-background"
-      data-testid="thread-view"
-    >
+    <div className="flex w-full h-full flex-col bg-background" data-testid="thread-view">
       {/* Header */}
       <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0">
-        <h3 className="font-semibold text-foreground text-sm">Thread</h3>
-        <Button size="icon" variant="ghost" className="h-8 w-8">
-          <X className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-2">
+          {isMobile && onClose && (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8"
+              onClick={onClose}
+              aria-label="Back to notes"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          )}
+          <h3 className="font-semibold text-foreground text-sm">Thread</h3>
+        </div>
+        {!isMobile && onClose && (
+          <Button size="icon" variant="ghost" className="h-8 w-8" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        )}
       </div>
 
       {/* Original Message */}

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQuery.matches);
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+};

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -15,12 +15,7 @@ import { useNotesUI } from '../store/notes.store';
 export const NotesPage: React.FC = () => {
   const { noteId } = useParams<{ noteId?: string }>();
   const navigate = useNavigate();
-  const {
-    selectedNoteId,
-    setSelectedNoteId,
-    replyingToNoteId,
-    stopReply,
-  } = useNotesUI();
+  const { selectedNoteId, setSelectedNoteId, replyingToNoteId, stopReply } = useNotesUI();
 
   // NOTE: Fetch notes with infinite scroll
   const {
@@ -53,6 +48,12 @@ export const NotesPage: React.FC = () => {
   const handleNoteSelect = (id: string) => {
     setSelectedNoteId(id);
     navigate(`/notes/${id}`);
+  };
+
+  // NOTE: Close thread view (mobile navigation)
+  const handleCloseThread = () => {
+    setSelectedNoteId(null);
+    navigate('/');
   };
 
   // NOTE: Create new note or reply
@@ -89,6 +90,8 @@ export const NotesPage: React.FC = () => {
     <div className="h-full w-full">
       {/* NOTE: Split view layout */}
       <SplitView
+        showRight={!!selectedNoteId}
+        onCloseRight={handleCloseThread}
         left={
           <NoteList
             notes={displayNotes}
@@ -106,6 +109,7 @@ export const NotesPage: React.FC = () => {
               <ThreadView
                 rootNote={noteData.note}
                 thread={noteData.thread || []}
+                onClose={handleCloseThread}
                 onReply={async (parentId: string, content: string) => {
                   await createNote.mutateAsync({
                     content,
@@ -125,8 +129,7 @@ export const NotesPage: React.FC = () => {
 
                     // NOTE: Clear selection if deleted note was selected
                     if (selectedNoteId === noteId) {
-                      setSelectedNoteId(null);
-                      navigate('/');
+                      handleCloseThread();
                     }
                   } catch (error) {
                     console.error('Failed to delete note:', error);


### PR DESCRIPTION
## Summary
スレッド表示のレスポンシブデザインを実装しました。画面サイズに応じて最適なレイアウトが表示されます。

- スレッド未選択時: 左カラムが画面いっぱいに表示
- スレッド選択時:
  - 広い画面(≥1024px): 左右分割表示
  - 狭い画面(<1024px): スレッドビューのみ全画面表示（戻るボタン付き）

## Changes
- `useMediaQuery` カスタムフックを追加（1024px ブレークポイント）
- `SplitView` をレスポンシブ対応に更新
- `ThreadView` にモバイル用戻るボタンを追加
- `NotesPage` でパネル表示を制御

## Test Plan
- [ ] デスクトップ画面でスレッド選択・未選択の動作確認
- [ ] モバイル画面でスレッド選択・未選択の動作確認
- [ ] 画面リサイズ時の動作確認
- [ ] 戻るボタンの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)