### PR TITLE
Add dark/light theme toggle to application header

### DIFF
--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -99,7 +99,7 @@ export const NoteList: React.FC<NoteListProps> = ({
   return (
     <div className="flex flex-col h-full w-full bg-background" data-testid="note-list">
       {/* Header */}
-      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0">
+      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0 relative z-10">
         <div className="flex items-center gap-2">
           <Hash className="h-5 w-5 text-muted-foreground" />
           <h1 className="font-semibold text-foreground text-lg">notes</h1>

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -99,12 +99,12 @@ export const NoteList: React.FC<NoteListProps> = ({
   return (
     <div className="flex flex-col h-full w-full bg-background" data-testid="note-list">
       {/* Header */}
-      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0 relative z-10">
+      <div className="flex h-14 items-center justify-between border-b border-border px-4 flex-shrink-0">
         <div className="flex items-center gap-2">
           <Hash className="h-5 w-5 text-muted-foreground" />
           <h1 className="font-semibold text-foreground text-lg">notes</h1>
         </div>
-        <div className="flex items-center gap-2 relative z-20">
+        <div className="flex items-center gap-2">
           <span className="text-muted-foreground text-xs" data-testid="note-list-count">
             {filteredNotes.length} notes
           </span>

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -104,7 +104,7 @@ export const NoteList: React.FC<NoteListProps> = ({
           <Hash className="h-5 w-5 text-muted-foreground" />
           <h1 className="font-semibold text-foreground text-lg">notes</h1>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 relative z-20">
           <span className="text-muted-foreground text-xs" data-testid="note-list-count">
             {filteredNotes.length} notes
           </span>

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from '@/lib/utils';
 import { getRelativeTime } from '@/lib/utils';
 import NoteEditor from './NoteEditor';
+import { ThemeToggle } from './ThemeToggle';
 
 interface NoteListProps {
   notes: Note[];
@@ -107,6 +108,7 @@ export const NoteList: React.FC<NoteListProps> = ({
           <span className="text-muted-foreground text-xs" data-testid="note-list-count">
             {filteredNotes.length} notes
           </span>
+          <ThemeToggle />
           <Button size="icon" variant="ghost" className="h-8 w-8">
             <Plus className="h-4 w-4" />
           </Button>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -29,7 +29,7 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8 relative z-50 pointer-events-auto">
+        <Button variant="ghost" size="icon" className="h-8 w-8">
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
@@ -9,7 +10,21 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
   const { setTheme } = useTheme();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="h-8 w-8">
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    );
+  }
 
   return (
     <DropdownMenu>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -29,7 +29,7 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8">
+        <Button variant="ghost" size="icon" className="h-8 w-8 relative z-50 pointer-events-auto">
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -36,25 +36,25 @@ const buttonVariants = cva(
   },
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : 'button'
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
       {...props}
     />
   )
-}
+})
+
+Button.displayName = 'Button'
 
 export { Button, buttonVariants }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ if (!root) {
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <App />
     </ThemeProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- Added theme toggle button to left side header for switching between light, dark, and system themes
- Theme defaults to system preference and persists user selection to localStorage
- Fixed Button component to properly support refs (required for Radix UI integration)

## Changes Made
### Core Implementation
- **ThemeToggle component** (`frontend/src/components/ThemeToggle.tsx`)
  - Dropdown menu with Light, Dark, and System options
  - Animated sun/moon icons based on current theme
  - Mounted state check to prevent hydration issues

- **NoteList header** (`frontend/src/components/NoteList.tsx`)
  - Integrated ThemeToggle button between note count and plus button

- **Main app** (`frontend/src/main.tsx`)
  - Changed default theme from "light" to "system" for browser alignment

### Bug Fixes
- **Button component** (`frontend/src/components/ui/button.tsx`)
  - Added `React.forwardRef` to support Radix UI's `asChild` prop
  - Prevents React ref errors when used with DropdownMenuTrigger

## Test Plan
- [x] Theme toggle button appears in left header
- [x] Clicking button opens dropdown menu
- [x] Switching to dark mode applies dark theme
- [x] Switching to light mode applies light theme
- [x] System mode follows browser/OS preference
- [x] Theme preference persists on page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)