### PR TITLE
fix: keyboard submission issue in NoteEditor

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -105,7 +105,7 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
         onCancel();
       }
     },
-    [onCancel]
+    [handleSubmit, onCancel]
   );
 
   const insertMention = useCallback(


### PR DESCRIPTION
## Summary
- Fixed keyboard submission (Cmd/Ctrl+Enter) not working in NoteEditor component
- Added `handleSubmit` to the `useCallback` dependency array for `handleKeyDown`

## Problem
The `handleKeyDown` callback was missing `handleSubmit` in its dependency array, causing a stale closure issue. When users pressed Cmd/Ctrl+Enter, the keyboard handler would use an outdated version of `handleSubmit` that didn't have access to the current `content` state.

## Solution
Updated the dependency array from `[onCancel]` to `[handleSubmit, onCancel]` on line 108 of `frontend/src/components/NoteEditor.tsx`.

## Test Plan
- [x] Tested keyboard submission with Cmd+Enter in browser
- [x] Verified note creation works with real backend API
- [x] Confirmed textarea clears after successful submission
- [x] TypeScript type checking passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)