### PR TITLE
feat: add user sync service for OAuth provider integration

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import notesRoutes from './routes/notes';
 import searchRoutes from './routes/search';
 import mentionsRoutes from './routes/mentions';
+import usersRoutes from './routes/users';
 import { errorHandler } from './middleware/error';
 
 // NOTE: Hono app instance and router setup
@@ -17,6 +18,7 @@ app.use('*', cors());
 app.route('/api/notes', searchRoutes);  // /search route
 app.route('/api/notes', mentionsRoutes); // /:id/mentions route
 app.route('/api/notes', notesRoutes);   // /:id route (must be last)
+app.route('/api/users', usersRoutes);   // /sync route
 
 // NOTE: Health check endpoint for monitoring
 app.get('/health', (c) => {

--- a/backend/src/api/routes/users/index.ts
+++ b/backend/src/api/routes/users/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono';
+import syncRoute from './sync';
+
+const app = new Hono();
+
+// NOTE: User management routes
+app.route('/sync', syncRoute);
+
+export default app;

--- a/backend/src/api/routes/users/sync.ts
+++ b/backend/src/api/routes/users/sync.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono';
+import { userSyncService } from '../../../auth/services/user-sync.service';
+import { IDENTITY_PROVIDERS } from '../../../models/external-identity.schema';
+import type { SyncUserRequest } from '../../../auth/types';
+
+const app = new Hono();
+
+// NOTE: Provider type guard for validation
+const isValidProvider = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  IDENTITY_PROVIDERS.includes(value as (typeof IDENTITY_PROVIDERS)[number]);
+
+// POST /api/users/sync - Sync OAuth provider user to local database
+app.post('/', async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400);
+  }
+
+  if (!body || typeof body !== 'object') {
+    return c.json({ error: 'Request body must be an object' }, 400);
+  }
+
+  const { provider, providerUserId } = body as Record<string, unknown>;
+
+  if (!isValidProvider(provider)) {
+    return c.json({ error: 'Invalid provider' }, 400);
+  }
+
+  if (typeof providerUserId !== 'string' || !providerUserId) {
+    return c.json({ error: 'providerUserId is required' }, 400);
+  }
+
+  try {
+    const result = await userSyncService.syncUser(body as SyncUserRequest);
+    return c.json(result);
+  } catch (error) {
+    console.error('User sync failed:', error);
+    return c.json({ error: 'Sync failed' }, 500);
+  }
+});
+
+export default app;

--- a/backend/src/auth/services/user-sync.service.ts
+++ b/backend/src/auth/services/user-sync.service.ts
@@ -1,0 +1,142 @@
+import { db } from '../../db';
+import { profiles } from '../../models/profile.schema';
+import { externalIdentities } from '../../models/external-identity.schema';
+import { eq, and } from 'drizzle-orm';
+import { generateId } from '../../utils/id-generator';
+import type { SyncUserRequest, SyncUserResponse } from '../types';
+import type { ExternalIdentity } from '../../models/external-identity.schema';
+
+// NOTE: Service for syncing OAuth provider users to local database (idempotent)
+export class UserSyncService {
+  async syncUser({
+    provider,
+    providerUserId,
+    email,
+    emailVerified,
+    displayName,
+    avatarUrl,
+    metadata,
+    providerCreatedAt,
+    providerUpdatedAt,
+  }: SyncUserRequest): Promise<SyncUserResponse> {
+    const existingIdentity = await this.findIdentity(provider, providerUserId);
+
+    if (existingIdentity) {
+      await this.updateProfile(existingIdentity.profileId, {
+        displayName,
+        avatarUrl,
+      });
+      await this.updateIdentity(existingIdentity.id, {
+        email,
+        emailVerified,
+        metadata,
+        providerUpdatedAt,
+      });
+      return {
+        synced: true,
+        profileId: existingIdentity.profileId,
+        identityId: existingIdentity.id,
+      };
+    }
+
+    const profileId = generateId();
+    const identityId = generateId();
+
+    await db.insert(profiles).values({
+      id: profileId,
+      displayName: displayName || email || 'User',
+      avatarUrl,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(externalIdentities).values({
+      id: identityId,
+      provider,
+      providerUserId,
+      profileId,
+      email,
+      emailVerified,
+      metadata,
+      providerCreatedAt: providerCreatedAt ? new Date(providerCreatedAt) : undefined,
+      providerUpdatedAt: providerUpdatedAt ? new Date(providerUpdatedAt) : undefined,
+      lastSyncedAt: new Date(),
+    });
+
+    return { synced: true, profileId, identityId };
+  }
+
+  private async findIdentity(
+    provider: string,
+    providerUserId: string
+  ): Promise<ExternalIdentity | undefined> {
+    const [identity] = await db
+      .select()
+      .from(externalIdentities)
+      .where(
+        and(
+          eq(externalIdentities.provider, provider),
+          eq(externalIdentities.providerUserId, providerUserId)
+        )
+      )
+      .limit(1);
+    return identity;
+  }
+
+  private async updateProfile(
+    profileId: string,
+    { displayName, avatarUrl }: { displayName?: string; avatarUrl?: string }
+  ): Promise<void> {
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+
+    if (displayName !== undefined) {
+      updateData.displayName = displayName;
+    }
+    if (avatarUrl !== undefined) {
+      updateData.avatarUrl = avatarUrl;
+    }
+
+    await db.update(profiles).set(updateData).where(eq(profiles.id, profileId));
+  }
+
+  private async updateIdentity(
+    identityId: string,
+    {
+      email,
+      emailVerified,
+      metadata,
+      providerUpdatedAt,
+    }: {
+      email?: string;
+      emailVerified?: boolean;
+      metadata?: Record<string, unknown>;
+      providerUpdatedAt?: string;
+    }
+  ): Promise<void> {
+    const updateData: Record<string, unknown> = {
+      lastSyncedAt: new Date(),
+    };
+
+    if (email !== undefined) {
+      updateData.email = email;
+    }
+    if (emailVerified !== undefined) {
+      updateData.emailVerified = emailVerified;
+    }
+    if (metadata !== undefined) {
+      updateData.metadata = metadata;
+    }
+    if (providerUpdatedAt !== undefined) {
+      updateData.providerUpdatedAt = new Date(providerUpdatedAt);
+    }
+
+    await db
+      .update(externalIdentities)
+      .set(updateData)
+      .where(eq(externalIdentities.id, identityId));
+  }
+}
+
+export const userSyncService = new UserSyncService();

--- a/backend/src/auth/types.ts
+++ b/backend/src/auth/types.ts
@@ -1,0 +1,19 @@
+// NOTE: Type definitions for auth domain - provider-agnostic user sync
+
+export interface SyncUserRequest {
+  provider: string;
+  providerUserId: string;
+  email?: string;
+  emailVerified?: boolean;
+  displayName?: string;
+  avatarUrl?: string;
+  metadata?: Record<string, unknown>;
+  providerCreatedAt?: string;
+  providerUpdatedAt?: string;
+}
+
+export interface SyncUserResponse {
+  synced: boolean;
+  profileId: string;
+  identityId: string;
+}

--- a/backend/tests/integration/user-sync.service.test.ts
+++ b/backend/tests/integration/user-sync.service.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db, profiles, externalIdentities } from '../../src/db';
+import { eq } from 'drizzle-orm';
+import { UserSyncService } from '../../src/auth/services/user-sync.service';
+import type { SyncUserRequest } from '../../src/auth/types';
+
+// NOTE: Integration tests for UserSyncService
+describe('UserSyncService', () => {
+  const userSync = new UserSyncService();
+
+  beforeEach(async () => {
+    await db.delete(externalIdentities);
+    await db.delete(profiles);
+  });
+
+  it('should create new profile and identity for new user', async () => {
+    const request: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'user_clerk123',
+      email: 'newuser@example.com',
+      emailVerified: true,
+      displayName: 'New User',
+      avatarUrl: 'https://example.com/avatar.jpg',
+      metadata: { firstName: 'New', lastName: 'User' },
+      providerCreatedAt: '2024-01-01T00:00:00Z',
+      providerUpdatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    const result = await userSync.syncUser(request);
+
+    expect(result.synced).toBe(true);
+    expect(result.profileId).toBeDefined();
+    expect(result.identityId).toBeDefined();
+
+    const [profile] = await db.select().from(profiles).where(eq(profiles.id, result.profileId));
+
+    expect(profile.displayName).toBe('New User');
+    expect(profile.avatarUrl).toBe('https://example.com/avatar.jpg');
+
+    const [identity] = await db
+      .select()
+      .from(externalIdentities)
+      .where(eq(externalIdentities.id, result.identityId));
+
+    expect(identity.provider).toBe('CLERK');
+    expect(identity.providerUserId).toBe('user_clerk123');
+    expect(identity.profileId).toBe(result.profileId);
+    expect(identity.email).toBe('newuser@example.com');
+    expect(identity.emailVerified).toBe(true);
+    expect(identity.metadata).toEqual({ firstName: 'New', lastName: 'User' });
+  });
+
+  it('should update existing profile and identity when syncing again', async () => {
+    const initialRequest: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'user_existing',
+      email: 'original@example.com',
+      displayName: 'Original Name',
+      avatarUrl: 'https://example.com/old.jpg',
+    };
+
+    const firstSync = await userSync.syncUser(initialRequest);
+
+    const updateRequest: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'user_existing',
+      email: 'updated@example.com',
+      emailVerified: true,
+      displayName: 'Updated Name',
+      avatarUrl: 'https://example.com/new.jpg',
+      metadata: { updated: true },
+      providerUpdatedAt: '2024-01-02T00:00:00Z',
+    };
+
+    const secondSync = await userSync.syncUser(updateRequest);
+
+    expect(secondSync.synced).toBe(true);
+    expect(secondSync.profileId).toBe(firstSync.profileId);
+    expect(secondSync.identityId).toBe(firstSync.identityId);
+
+    const [profile] = await db.select().from(profiles).where(eq(profiles.id, secondSync.profileId));
+
+    expect(profile.displayName).toBe('Updated Name');
+    expect(profile.avatarUrl).toBe('https://example.com/new.jpg');
+
+    const [identity] = await db
+      .select()
+      .from(externalIdentities)
+      .where(eq(externalIdentities.id, secondSync.identityId));
+
+    expect(identity.email).toBe('updated@example.com');
+    expect(identity.emailVerified).toBe(true);
+    expect(identity.metadata).toEqual({ updated: true });
+  });
+
+  it('should be idempotent (multiple syncs with same data)', async () => {
+    const request: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'user_idempotent',
+      email: 'idempotent@example.com',
+      displayName: 'Idempotent User',
+    };
+
+    const first = await userSync.syncUser(request);
+    const second = await userSync.syncUser(request);
+    const third = await userSync.syncUser(request);
+
+    expect(second.profileId).toBe(first.profileId);
+    expect(second.identityId).toBe(first.identityId);
+    expect(third.profileId).toBe(first.profileId);
+    expect(third.identityId).toBe(first.identityId);
+
+    const allProfiles = await db.select().from(profiles);
+    const allIdentities = await db.select().from(externalIdentities);
+
+    expect(allProfiles).toHaveLength(1);
+    expect(allIdentities).toHaveLength(1);
+  });
+
+  it('should handle minimal user data (no email, use fallback displayName)', async () => {
+    const request: SyncUserRequest = {
+      provider: 'GOOGLE',
+      providerUserId: 'google_minimal',
+    };
+
+    const result = await userSync.syncUser(request);
+
+    expect(result.synced).toBe(true);
+
+    const [profile] = await db.select().from(profiles).where(eq(profiles.id, result.profileId));
+
+    expect(profile.displayName).toBe('User');
+  });
+
+  it('should use email as displayName if name not provided', async () => {
+    const request: SyncUserRequest = {
+      provider: 'AUTH0',
+      providerUserId: 'auth0_email_only',
+      email: 'emailuser@example.com',
+    };
+
+    const result = await userSync.syncUser(request);
+
+    const [profile] = await db.select().from(profiles).where(eq(profiles.id, result.profileId));
+
+    expect(profile.displayName).toBe('emailuser@example.com');
+  });
+
+  it('should allow different providers for different users', async () => {
+    const clerkUser: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'clerk_user',
+      email: 'clerk@example.com',
+      displayName: 'Clerk User',
+    };
+
+    const googleUser: SyncUserRequest = {
+      provider: 'GOOGLE',
+      providerUserId: 'google_user',
+      email: 'google@example.com',
+      displayName: 'Google User',
+    };
+
+    const clerkResult = await userSync.syncUser(clerkUser);
+    const googleResult = await userSync.syncUser(googleUser);
+
+    expect(clerkResult.profileId).not.toBe(googleResult.profileId);
+    expect(clerkResult.identityId).not.toBe(googleResult.identityId);
+
+    const allProfiles = await db.select().from(profiles);
+    const allIdentities = await db.select().from(externalIdentities);
+
+    expect(allProfiles).toHaveLength(2);
+    expect(allIdentities).toHaveLength(2);
+  });
+
+  it('should update lastSyncedAt on every sync', async () => {
+    const request: SyncUserRequest = {
+      provider: 'CLERK',
+      providerUserId: 'user_sync_time',
+      email: 'synctime@example.com',
+    };
+
+    const first = await userSync.syncUser(request);
+    const [firstIdentity] = await db
+      .select()
+      .from(externalIdentities)
+      .where(eq(externalIdentities.id, first.identityId));
+
+    const firstSyncTime = firstIdentity.lastSyncedAt;
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await userSync.syncUser(request);
+    const [secondIdentity] = await db
+      .select()
+      .from(externalIdentities)
+      .where(eq(externalIdentities.id, first.identityId));
+
+    const secondSyncTime = secondIdentity.lastSyncedAt;
+
+    expect(secondSyncTime.getTime()).toBeGreaterThan(firstSyncTime.getTime());
+  });
+});


### PR DESCRIPTION
## Summary
Implement idempotent user synchronization service for OAuth providers (e.g., Clerk). This is **Step 2** of the Clerk authentication implementation.

### Key Features
- **UserSyncService** with idempotent `syncUser` method
- Creates/updates `profiles` and `external_identities` records
- POST `/api/users/sync` endpoint with validation
- Integration tests with 100% pass rate

### Changes
- ✅ Add `UserSyncService` for OAuth user sync (142 lines)
- ✅ Create `/api/users/sync` endpoint with type guards
- ✅ Add `SyncUserRequest`/`SyncUserResponse` types
- ✅ Include integration tests (7 tests, 33 assertions)

### Testing
- All 7 integration tests pass ✅
- Idempotency verified (re-sync updates, doesn't duplicate)
- Edge cases covered (missing fields, validation)

### Next Steps
- Step 3: Authentication middleware
- Step 4: Install Clerk dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)