### PR TITLE
fix: change thread reply input to use Cmd/Ctrl+Enter for submission

### DIFF
--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -437,11 +437,11 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
         <div className="flex items-end gap-2">
           <div className="flex-1 rounded-lg border border-input bg-card">
             <Input
-              placeholder="Reply..."
+              placeholder="Reply... (Cmd/Ctrl+Enter to send)"
               value={replyContent}
               onChange={(e) => setReplyContent(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
                   handleReply();
                 }


### PR DESCRIPTION
Previously, the thread reply input would submit on any Enter key press,
which interfered with IME (Japanese input method) composition where
Enter is used to confirm character conversion.

Changes:
- Modified onKeyDown handler to require Cmd/Ctrl+Enter for submission
- Updated placeholder text to indicate the new keyboard shortcut
- Now consistent with the main note editor behavior

This prevents accidental submissions during Japanese text input while
maintaining easy submission via keyboard shortcut.