### PR TITLE
fix: make text inputs always visible in scrollable views

### DIFF
--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -132,191 +132,193 @@ export const NoteList: React.FC<NoteListProps> = ({
       </div>
 
       {/* Note Feed */}
-      <ScrollArea className="flex-1">
-        <div className="space-y-0 p-4">
-          {filteredNotes.map((note) => (
-            <div
-              key={note.id}
-              className={cn(
-                'group relative w-full rounded-lg px-4 py-3 transition-colors hover:bg-accent',
-                selectedNoteId === note.id && 'bg-accent/50'
-              )}
-              data-testid="note-item"
-            >
-              {/* Action Menu */}
-              <div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button size="icon" variant="ghost" className="h-7 w-7">
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem>
-                      <Pin className="mr-2 h-4 w-4" />
-                      Pin note
-                    </DropdownMenuItem>
-                    <DropdownMenuItem>
-                      <Bookmark className="mr-2 h-4 w-4" />
-                      Bookmark
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => copyLink(note.id)}>
-                      <Link2 className="mr-2 h-4 w-4" />
-                      Copy link
-                    </DropdownMenuItem>
-                    <DropdownMenuItem>
-                      <Edit className="mr-2 h-4 w-4" />
-                      Edit note
-                    </DropdownMenuItem>
-                    <DropdownMenuItem className="text-destructive">
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete note
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <ScrollArea className="h-full">
+          <div className="space-y-0 p-4">
+            {filteredNotes.map((note) => (
+              <div
+                key={note.id}
+                className={cn(
+                  'group relative w-full rounded-lg px-4 py-3 transition-colors hover:bg-accent',
+                  selectedNoteId === note.id && 'bg-accent/50'
+                )}
+                data-testid="note-item"
+              >
+                {/* Action Menu */}
+                <div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button size="icon" variant="ghost" className="h-7 w-7">
+                        <MoreVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem>
+                        <Pin className="mr-2 h-4 w-4" />
+                        Pin note
+                      </DropdownMenuItem>
+                      <DropdownMenuItem>
+                        <Bookmark className="mr-2 h-4 w-4" />
+                        Bookmark
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => copyLink(note.id)}>
+                        <Link2 className="mr-2 h-4 w-4" />
+                        Copy link
+                      </DropdownMenuItem>
+                      <DropdownMenuItem>
+                        <Edit className="mr-2 h-4 w-4" />
+                        Edit note
+                      </DropdownMenuItem>
+                      <DropdownMenuItem className="text-destructive">
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete note
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
 
-              {/* Note Content */}
-              <button onClick={() => handleNoteClick(note.id)} className="w-full text-left">
-                <div className="space-y-2">
-                  {/* Tags */}
-                  {note.tags && note.tags.length > 0 && (
-                    <div className="flex gap-1.5">
-                      {note.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Header with ID and Timestamp */}
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="rounded bg-primary/10 px-2 py-0.5 font-mono font-medium text-primary text-xs"
-                        data-testid="note-item-id"
-                      >
-                        #{note.id}
-                      </span>
-                      <span className="text-muted-foreground text-xs">
-                        {getRelativeTime(note.createdAt)}
-                      </span>
-                      {note.replyCount !== undefined && note.replyCount > 0 && (
-                        <span
-                          className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/20 px-1.5 font-medium text-primary text-xs"
-                          data-testid="note-item-reply-count"
-                        >
-                          {note.replyCount}
-                        </span>
-                      )}
-                      {note.bookmarked && (
-                        <Bookmark className="h-3 w-3 fill-yellow-500 text-yellow-500" />
-                      )}
-                    </div>
-                    {note.pinned && <Pin className="h-4 w-4 fill-primary text-primary" />}
-                  </div>
-
-                  {/* Content */}
+                {/* Note Content */}
+                <button onClick={() => handleNoteClick(note.id)} className="w-full text-left">
                   <div className="space-y-2">
-                    <p
-                      className="text-foreground text-sm leading-relaxed"
-                      data-testid="note-item-content"
-                    >
-                      {truncateContent(note.content)}
-                    </p>
+                    {/* Tags */}
+                    {note.tags && note.tags.length > 0 && (
+                      <div className="flex gap-1.5">
+                        {note.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
 
-                    {/* Image Previews */}
-                    {note.images && note.images.length > 0 && (
-                      <div className="space-y-2">
-                        {expandedImages[note.id] ? (
-                          // Expanded: show all images
-                          <>
-                            {note.images.map((img, i) => (
-                              <img
-                                key={i}
-                                src={img}
-                                alt={`Image ${i + 1}`}
-                                className="w-full rounded-lg border border-border"
-                              />
-                            ))}
+                    {/* Header with ID and Timestamp */}
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="rounded bg-primary/10 px-2 py-0.5 font-mono font-medium text-primary text-xs"
+                          data-testid="note-item-id"
+                        >
+                          #{note.id}
+                        </span>
+                        <span className="text-muted-foreground text-xs">
+                          {getRelativeTime(note.createdAt)}
+                        </span>
+                        {note.replyCount !== undefined && note.replyCount > 0 && (
+                          <span
+                            className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/20 px-1.5 font-medium text-primary text-xs"
+                            data-testid="note-item-reply-count"
+                          >
+                            {note.replyCount}
+                          </span>
+                        )}
+                        {note.bookmarked && (
+                          <Bookmark className="h-3 w-3 fill-yellow-500 text-yellow-500" />
+                        )}
+                      </div>
+                      {note.pinned && <Pin className="h-4 w-4 fill-primary text-primary" />}
+                    </div>
+
+                    {/* Content */}
+                    <div className="space-y-2">
+                      <p
+                        className="text-foreground text-sm leading-relaxed"
+                        data-testid="note-item-content"
+                      >
+                        {truncateContent(note.content)}
+                      </p>
+
+                      {/* Image Previews */}
+                      {note.images && note.images.length > 0 && (
+                        <div className="space-y-2">
+                          {expandedImages[note.id] ? (
+                            // Expanded: show all images
+                            <>
+                              {note.images.map((img, i) => (
+                                <img
+                                  key={i}
+                                  src={img}
+                                  alt={`Image ${i + 1}`}
+                                  className="w-full rounded-lg border border-border"
+                                />
+                              ))}
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleImageExpansion(note.id);
+                                }}
+                                className="text-primary text-xs hover:underline"
+                              >
+                                Collapse images
+                              </button>
+                            </>
+                          ) : (
+                            // Collapsed: thumbnail stack
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
                                 toggleImageExpansion(note.id);
                               }}
-                              className="text-primary text-xs hover:underline"
+                              className="flex items-center gap-2"
                             >
-                              Collapse images
+                              <div className="flex -space-x-2">
+                                {note.images.slice(0, 3).map((img, i) => (
+                                  <img
+                                    key={i}
+                                    src={img}
+                                    alt={`Thumbnail ${i + 1}`}
+                                    className="h-12 w-12 rounded border-2 border-background object-cover"
+                                  />
+                                ))}
+                              </div>
+                              <span className="text-muted-foreground text-xs">
+                                {note.images.length} {note.images.length === 1 ? 'image' : 'images'}{' '}
+                                - Click to expand
+                              </span>
                             </button>
-                          </>
-                        ) : (
-                          // Collapsed: thumbnail stack
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              toggleImageExpansion(note.id);
-                            }}
-                            className="flex items-center gap-2"
-                          >
-                            <div className="flex -space-x-2">
-                              {note.images.slice(0, 3).map((img, i) => (
-                                <img
-                                  key={i}
-                                  src={img}
-                                  alt={`Thumbnail ${i + 1}`}
-                                  className="h-12 w-12 rounded border-2 border-background object-cover"
-                                />
-                              ))}
-                            </div>
-                            <span className="text-muted-foreground text-xs">
-                              {note.images.length} {note.images.length === 1 ? 'image' : 'images'} -
-                              Click to expand
-                            </span>
-                          </button>
-                        )}
-                      </div>
-                    )}
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </button>
-            </div>
-          ))}
-
-          {/* Loading State */}
-          {loading && (
-            <div
-              className="flex items-center justify-center gap-2 p-4"
-              data-testid="note-list-loading"
-            >
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-              <span className="text-muted-foreground text-sm">Loading more notes...</span>
-            </div>
-          )}
-
-          {/* Load More Trigger */}
-          {hasMore && !loading && <div ref={loadMoreRef} className="h-4" />}
-
-          {/* Empty State */}
-          {!loading && filteredNotes.length === 0 && (
-            <div
-              className="flex flex-col items-center justify-center gap-2 p-8"
-              data-testid="note-list-empty"
-            >
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent">
-                <Hash className="h-6 w-6 text-muted-foreground" />
+                </button>
               </div>
-              <p className="text-foreground text-sm">No notes yet</p>
-              <p className="text-muted-foreground text-xs">
-                Create your first note to get started!
-              </p>
-            </div>
-          )}
-        </div>
-      </ScrollArea>
+            ))}
+
+            {/* Loading State */}
+            {loading && (
+              <div
+                className="flex items-center justify-center gap-2 p-4"
+                data-testid="note-list-loading"
+              >
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <span className="text-muted-foreground text-sm">Loading more notes...</span>
+              </div>
+            )}
+
+            {/* Load More Trigger */}
+            {hasMore && !loading && <div ref={loadMoreRef} className="h-4" />}
+
+            {/* Empty State */}
+            {!loading && filteredNotes.length === 0 && (
+              <div
+                className="flex flex-col items-center justify-center gap-2 p-8"
+                data-testid="note-list-empty"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent">
+                  <Hash className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <p className="text-foreground text-sm">No notes yet</p>
+                <p className="text-muted-foreground text-xs">
+                  Create your first note to get started!
+                </p>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
 
       {/* Note Editor at bottom */}
       {onCreateNote && (

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -12,6 +12,7 @@ import {
   Edit,
   Pin,
   ArrowLeft,
+  Smile,
 } from 'lucide-react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
@@ -136,301 +137,304 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
         )}
       </div>
 
-      {/* Original Message */}
-      <div className="border-b border-border p-4 flex-shrink-0">
-        <div className="group relative space-y-2" data-testid="thread-node">
-          <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="icon" variant="ghost" className="h-7 w-7">
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem>
-                  <Pin className="mr-2 h-4 w-4" />
-                  Pin note
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Bookmark className="mr-2 h-4 w-4" />
-                  Bookmark
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => copyLink(rootNote.id)}>
-                  <Link2 className="mr-2 h-4 w-4" />
-                  Copy link
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => setIsEditing(rootNote.id)}
-                  data-testid="thread-action-edit"
-                >
-                  <Edit className="mr-2 h-4 w-4" />
-                  Edit note
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => handleDelete(rootNote.id)}
-                  className="text-destructive"
-                  data-testid="thread-action-delete"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete note
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-
-          {/* Tags */}
-          {rootNote.tags && rootNote.tags.length > 0 && (
-            <div className="flex gap-1.5">
-              {rootNote.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <span
-                className="rounded bg-primary/10 px-2 py-0.5 font-mono font-medium text-primary text-xs"
-                data-testid="thread-node-id"
-              >
-                #{rootNote.id}
-              </span>
-              <span className="text-muted-foreground text-xs">
-                {getRelativeTime(rootNote.createdAt)}
-              </span>
-              {rootNote.bookmarked && (
-                <Bookmark className="h-3 w-3 fill-yellow-500 text-yellow-500" />
-              )}
-            </div>
-            {rootNote.pinned && <Pin className="h-4 w-4 fill-primary text-primary" />}
-          </div>
-
-          {isEditing === rootNote.id ? (
-            <NoteEditor
-              initialContent={rootNote.content}
-              onSubmit={(content) => handleEdit(rootNote.id, content)}
-              onCancel={() => setIsEditing(null)}
-              maxLength={1000}
-              autoFocus
-            />
-          ) : (
-            <>
-              <p
-                className="text-foreground text-sm leading-relaxed"
-                data-testid="thread-node-content"
-              >
-                {renderContent(rootNote.content)}
-              </p>
-
-              {/* Image Previews */}
-              {rootNote.images && rootNote.images.length > 0 && (
-                <div className="space-y-2">
-                  {expandedImages[rootNote.id] ? (
-                    // Expanded: show all images
-                    <>
-                      {rootNote.images.map((img, i) => (
-                        <img
-                          key={i}
-                          src={img}
-                          alt={`Image ${i + 1}`}
-                          className="w-full rounded-lg border border-border"
-                        />
-                      ))}
-                      <button
-                        onClick={() => toggleImageExpansion(rootNote.id)}
-                        className="text-primary text-xs hover:underline"
-                      >
-                        Collapse images
-                      </button>
-                    </>
-                  ) : (
-                    // Collapsed: thumbnail stack
-                    <button
-                      onClick={() => toggleImageExpansion(rootNote.id)}
-                      className="flex items-center gap-2"
+      {/* Scrollable Messages Container */}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <ScrollArea className="h-full">
+          {/* Original Message */}
+          <div className="border-b border-border p-4">
+            <div className="group relative space-y-2" data-testid="thread-node">
+              <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="icon" variant="ghost" className="h-7 w-7">
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem>
+                      <Pin className="mr-2 h-4 w-4" />
+                      Pin note
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <Bookmark className="mr-2 h-4 w-4" />
+                      Bookmark
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => copyLink(rootNote.id)}>
+                      <Link2 className="mr-2 h-4 w-4" />
+                      Copy link
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setIsEditing(rootNote.id)}
+                      data-testid="thread-action-edit"
                     >
-                      <div className="flex -space-x-2">
-                        {rootNote.images.slice(0, 3).map((img, i) => (
-                          <img
-                            key={i}
-                            src={img}
-                            alt={`Thumbnail ${i + 1}`}
-                            className="h-12 w-12 rounded border-2 border-background object-cover"
-                          />
-                        ))}
-                      </div>
-                      <span className="text-muted-foreground text-xs">
-                        {rootNote.images.length} {rootNote.images.length === 1 ? 'image' : 'images'}{' '}
-                        - Click to expand
-                      </span>
-                    </button>
-                  )}
+                      <Edit className="mr-2 h-4 w-4" />
+                      Edit note
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleDelete(rootNote.id)}
+                      className="text-destructive"
+                      data-testid="thread-action-delete"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete note
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              {/* Tags */}
+              {rootNote.tags && rootNote.tags.length > 0 && (
+                <div className="flex gap-1.5">
+                  {rootNote.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
+                    >
+                      {tag}
+                    </span>
+                  ))}
                 </div>
               )}
-            </>
-          )}
 
-          <div className="text-muted-foreground text-xs">
-            {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
-          </div>
-        </div>
-      </div>
-
-      {/* Thread Replies */}
-      <ScrollArea className="flex-1">
-        <div className="space-y-3 p-4">
-          {replies.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center">
-              <div className="mb-4 rounded-full bg-accent p-4">
-                <Smile className="h-8 w-8 text-muted-foreground/50" />
-              </div>
-              <p className="font-medium text-foreground text-sm">No replies yet</p>
-              <p className="text-muted-foreground text-xs">Be the first to reply to this note</p>
-            </div>
-          ) : (
-            replies.map((note) => (
-              <div key={note.id} className="group relative space-y-2" data-testid="thread-node">
-                <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button size="icon" variant="ghost" className="h-7 w-7">
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem>
-                        <Bookmark className="mr-2 h-4 w-4" />
-                        Bookmark
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => copyLink(note.id)}>
-                        <Link2 className="mr-2 h-4 w-4" />
-                        Copy link
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => setIsEditing(note.id)}
-                        data-testid="thread-action-edit"
-                      >
-                        <Edit className="mr-2 h-4 w-4" />
-                        Edit note
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleDelete(note.id)}
-                        className="text-destructive"
-                        data-testid="thread-action-delete"
-                      >
-                        <Trash2 className="mr-2 h-4 w-4" />
-                        Delete note
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-
-                {/* Tags */}
-                {note.tags && note.tags.length > 0 && (
-                  <div className="flex gap-1.5">
-                    {note.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                )}
-
+              <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2">
                   <span
                     className="rounded bg-primary/10 px-2 py-0.5 font-mono font-medium text-primary text-xs"
                     data-testid="thread-node-id"
                   >
-                    #{note.id}
+                    #{rootNote.id}
                   </span>
                   <span className="text-muted-foreground text-xs">
-                    {getRelativeTime(note.createdAt)}
+                    {getRelativeTime(rootNote.createdAt)}
                   </span>
-                  {note.updatedAt && note.updatedAt !== note.createdAt && (
-                    <span className="text-muted-foreground text-xs">(edited)</span>
-                  )}
-                  {note.bookmarked && (
+                  {rootNote.bookmarked && (
                     <Bookmark className="h-3 w-3 fill-yellow-500 text-yellow-500" />
                   )}
                 </div>
+                {rootNote.pinned && <Pin className="h-4 w-4 fill-primary text-primary" />}
+              </div>
 
-                {isEditing === note.id ? (
-                  <NoteEditor
-                    initialContent={note.content}
-                    onSubmit={(content) => handleEdit(note.id, content)}
-                    onCancel={() => setIsEditing(null)}
-                    maxLength={1000}
-                    autoFocus
-                  />
-                ) : (
-                  <>
-                    <p
-                      className="text-foreground text-sm leading-relaxed"
-                      data-testid="thread-node-content"
-                    >
-                      {renderContent(note.content)}
-                    </p>
+              {isEditing === rootNote.id ? (
+                <NoteEditor
+                  initialContent={rootNote.content}
+                  onSubmit={(content) => handleEdit(rootNote.id, content)}
+                  onCancel={() => setIsEditing(null)}
+                  maxLength={1000}
+                  autoFocus
+                />
+              ) : (
+                <>
+                  <p
+                    className="text-foreground text-sm leading-relaxed"
+                    data-testid="thread-node-content"
+                  >
+                    {renderContent(rootNote.content)}
+                  </p>
 
-                    {/* Image Previews */}
-                    {note.images && note.images.length > 0 && (
-                      <div className="space-y-2">
-                        {expandedImages[note.id] ? (
-                          // Expanded: show all images
-                          <>
-                            {note.images.map((img, i) => (
+                  {/* Image Previews */}
+                  {rootNote.images && rootNote.images.length > 0 && (
+                    <div className="space-y-2">
+                      {expandedImages[rootNote.id] ? (
+                        // Expanded: show all images
+                        <>
+                          {rootNote.images.map((img, i) => (
+                            <img
+                              key={i}
+                              src={img}
+                              alt={`Image ${i + 1}`}
+                              className="w-full rounded-lg border border-border"
+                            />
+                          ))}
+                          <button
+                            onClick={() => toggleImageExpansion(rootNote.id)}
+                            className="text-primary text-xs hover:underline"
+                          >
+                            Collapse images
+                          </button>
+                        </>
+                      ) : (
+                        // Collapsed: thumbnail stack
+                        <button
+                          onClick={() => toggleImageExpansion(rootNote.id)}
+                          className="flex items-center gap-2"
+                        >
+                          <div className="flex -space-x-2">
+                            {rootNote.images.slice(0, 3).map((img, i) => (
                               <img
                                 key={i}
                                 src={img}
-                                alt={`Image ${i + 1}`}
-                                className="w-full rounded-lg border border-border"
+                                alt={`Thumbnail ${i + 1}`}
+                                className="h-12 w-12 rounded border-2 border-background object-cover"
                               />
                             ))}
-                            <button
-                              onClick={() => toggleImageExpansion(note.id)}
-                              className="text-primary text-xs hover:underline"
-                            >
-                              Collapse images
-                            </button>
-                          </>
-                        ) : (
-                          // Collapsed: thumbnail stack
-                          <button
-                            onClick={() => toggleImageExpansion(note.id)}
-                            className="flex items-center gap-2"
-                          >
-                            <div className="flex -space-x-2">
-                              {note.images.slice(0, 3).map((img, i) => (
+                          </div>
+                          <span className="text-muted-foreground text-xs">
+                            {rootNote.images.length}{' '}
+                            {rootNote.images.length === 1 ? 'image' : 'images'} - Click to expand
+                          </span>
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+
+              <div className="text-muted-foreground text-xs">
+                {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
+              </div>
+            </div>
+          </div>
+
+          {/* Thread Replies */}
+          <div className="space-y-3 p-4">
+            {replies.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <div className="mb-4 rounded-full bg-accent p-4">
+                  <Smile className="h-8 w-8 text-muted-foreground/50" />
+                </div>
+                <p className="font-medium text-foreground text-sm">No replies yet</p>
+                <p className="text-muted-foreground text-xs">Be the first to reply to this note</p>
+              </div>
+            ) : (
+              replies.map((note) => (
+                <div key={note.id} className="group relative space-y-2" data-testid="thread-node">
+                  <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button size="icon" variant="ghost" className="h-7 w-7">
+                          <MoreVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem>
+                          <Bookmark className="mr-2 h-4 w-4" />
+                          Bookmark
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => copyLink(note.id)}>
+                          <Link2 className="mr-2 h-4 w-4" />
+                          Copy link
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => setIsEditing(note.id)}
+                          data-testid="thread-action-edit"
+                        >
+                          <Edit className="mr-2 h-4 w-4" />
+                          Edit note
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => handleDelete(note.id)}
+                          className="text-destructive"
+                          data-testid="thread-action-delete"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete note
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+
+                  {/* Tags */}
+                  {note.tags && note.tags.length > 0 && (
+                    <div className="flex gap-1.5">
+                      {note.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded bg-primary/10 px-2 py-0.5 font-medium text-primary text-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="rounded bg-primary/10 px-2 py-0.5 font-mono font-medium text-primary text-xs"
+                      data-testid="thread-node-id"
+                    >
+                      #{note.id}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {getRelativeTime(note.createdAt)}
+                    </span>
+                    {note.updatedAt && note.updatedAt !== note.createdAt && (
+                      <span className="text-muted-foreground text-xs">(edited)</span>
+                    )}
+                    {note.bookmarked && (
+                      <Bookmark className="h-3 w-3 fill-yellow-500 text-yellow-500" />
+                    )}
+                  </div>
+
+                  {isEditing === note.id ? (
+                    <NoteEditor
+                      initialContent={note.content}
+                      onSubmit={(content) => handleEdit(note.id, content)}
+                      onCancel={() => setIsEditing(null)}
+                      maxLength={1000}
+                      autoFocus
+                    />
+                  ) : (
+                    <>
+                      <p
+                        className="text-foreground text-sm leading-relaxed"
+                        data-testid="thread-node-content"
+                      >
+                        {renderContent(note.content)}
+                      </p>
+
+                      {/* Image Previews */}
+                      {note.images && note.images.length > 0 && (
+                        <div className="space-y-2">
+                          {expandedImages[note.id] ? (
+                            // Expanded: show all images
+                            <>
+                              {note.images.map((img, i) => (
                                 <img
                                   key={i}
                                   src={img}
-                                  alt={`Thumbnail ${i + 1}`}
-                                  className="h-12 w-12 rounded border-2 border-background object-cover"
+                                  alt={`Image ${i + 1}`}
+                                  className="w-full rounded-lg border border-border"
                                 />
                               ))}
-                            </div>
-                            <span className="text-muted-foreground text-xs">
-                              {note.images.length} {note.images.length === 1 ? 'image' : 'images'} -
-                              Click to expand
-                            </span>
-                          </button>
-                        )}
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-            ))
-          )}
-        </div>
-      </ScrollArea>
+                              <button
+                                onClick={() => toggleImageExpansion(note.id)}
+                                className="text-primary text-xs hover:underline"
+                              >
+                                Collapse images
+                              </button>
+                            </>
+                          ) : (
+                            // Collapsed: thumbnail stack
+                            <button
+                              onClick={() => toggleImageExpansion(note.id)}
+                              className="flex items-center gap-2"
+                            >
+                              <div className="flex -space-x-2">
+                                {note.images.slice(0, 3).map((img, i) => (
+                                  <img
+                                    key={i}
+                                    src={img}
+                                    alt={`Thumbnail ${i + 1}`}
+                                    className="h-12 w-12 rounded border-2 border-background object-cover"
+                                  />
+                                ))}
+                              </div>
+                              <span className="text-muted-foreground text-xs">
+                                {note.images.length} {note.images.length === 1 ? 'image' : 'images'}{' '}
+                                - Click to expand
+                              </span>
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </div>
 
       {/* Reply Input */}
       <div className="border-t border-border p-4 flex-shrink-0" data-testid="thread-reply-input">


### PR DESCRIPTION
## Summary
- Fixed ScrollArea layout in NoteList and ThreadView to ensure text inputs remain visible at the bottom when there are many messages
- Wrapped ScrollArea components with proper flex container (flex-1 min-h-0 overflow-hidden)
- Set ScrollArea to h-full for correct height calculation

## Problem
When there were many messages in either the note list or thread view, the text input would be pushed off-screen and become inaccessible.

## Solution
The issue was that Radix UI's ScrollArea needs explicit height constraints when used in flex layouts. The fix:

1. Wrap ScrollArea in a container with `flex-1 min-h-0 overflow-hidden`
2. Set ScrollArea to `h-full` to fill its container
3. This allows the ScrollArea to take remaining space and scroll properly

## Files Changed
- `frontend/src/components/NoteList.tsx` - Fixed left-side note input visibility
- `frontend/src/components/ThreadView.tsx` - Fixed right-side reply input visibility

## Test Plan
- [x] Verified with Chrome DevTools that inputs are within viewport
- [x] Confirmed ScrollArea has proper height values
- [x] Tested with multiple messages - inputs remain visible
- [x] Lint, typecheck, and format all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)