### PR TITLE
Fix user sync null reference error

### DIFF
--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -4,7 +4,6 @@ import { db } from '../../db';
 import { requireAuth } from '../../auth/middleware/auth.middleware';
 
 const users = new Hono();
-const userSyncService = new UserSyncService({ db });
 
 // NOTE: Protected endpoint - requires authentication
 users.post('/sync', requireAuth, async (c) => {
@@ -34,6 +33,8 @@ users.post('/sync', requireAuth, async (c) => {
       );
     }
 
+    // NOTE: Instantiate service at request time to ensure db is initialized
+    const userSyncService = new UserSyncService({ db });
     const result = await userSyncService.syncUser(body);
 
     return c.json(result, 200);


### PR DESCRIPTION
Move UserSyncService instantiation from module top-level to inside the request handler. This ensures db is properly initialized via setDb() before the service is created, fixing the "Cannot read properties of null (reading 'select')" error.