### PR TITLE
test: add integration tests for all routes

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -80,18 +80,42 @@ jobs:
           NODE_ENV: test
           DATABASE_URL: ../data/test.db
 
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run integration tests
+        run: bun run test:integration
+        env:
+          NODE_ENV: test
+
   # Summary job - required for branch protection
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-tests]
+    needs: [lint, typecheck, unit-tests, integration-tests]
     if: always()
     steps:
       - name: Check test results
         run: |
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
-             [[ "${{ needs.unit-tests.result }}" != "success" ]]; then
+             [[ "${{ needs.unit-tests.result }}" != "success" ]] || \
+             [[ "${{ needs.integration-tests.result }}" != "success" ]]; then
             echo "One or more required checks failed"
             exit 1
           fi

--- a/backend/src/api/routes/mentions.ts
+++ b/backend/src/api/routes/mentions.ts
@@ -18,10 +18,15 @@ const app = createRouter()
 
     const { id } = c.req.valid('param');
 
-    // NOTE: Check if note exists first
-    const note = await noteService.getNoteById(id);
-    if (!note) {
-      return c.json({ error: 'Not Found', message: 'Note not found' }, 404);
+    // NOTE: Check if note exists first using ResultAsync
+    const noteResult = await noteService.getNoteById(id);
+
+    if (noteResult.isErr()) {
+      const error = noteResult.error;
+      if (error._tag === 'NoteNotFoundError') {
+        return c.json({ error: 'Not Found', message: 'Note not found' }, 404);
+      }
+      return c.json({ error: error._tag, message: error.message }, 500);
     }
 
     const mentionsWithNotes = await mentionService.getMentionsWithNotes(id);

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -1,10 +1,10 @@
 import { UserSyncService, type SyncUserDto } from '../../services/user-sync.service';
-import { db } from '../../db';
 import { requireAuth } from '../../middleware/auth.middleware';
 import { createRouter } from './router';
 
 const users = createRouter().post('/sync', requireAuth, async (c) => {
   try {
+    const db = c.get('db');
     const body = await c.req.json<SyncUserDto>();
 
     // NOTE: Validate required fields

--- a/backend/tests/integration/mentions.routes.test.ts
+++ b/backend/tests/integration/mentions.routes.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Integration tests for mentions routes
+ *
+ * Tests the actual HTTP endpoints for getting notes that mention a specific note.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { env } from 'cloudflare:test';
+import { Hono } from 'hono';
+import type { ClerkClient } from '@clerk/backend';
+import mentionsRoutes from '../../src/api/routes/mentions';
+import { errorHandler } from '../../src/middleware/error';
+import { generateId } from '../../src/utils/id-generator';
+
+// NOTE: Mock the getClerkClient function
+const mockAuthenticateRequest = vi.fn();
+const mockClerkClient: Partial<ClerkClient> = {
+  authenticateRequest: mockAuthenticateRequest,
+};
+
+vi.mock('../../src/auth/clerk', () => ({
+  getClerkClient: () => mockClerkClient,
+}));
+
+type TestBindings = {
+  DB: D1Database;
+  CLERK_SECRET_KEY: string;
+  CLERK_PUBLISHABLE_KEY: string;
+  ALLOWED_ORIGINS: string;
+  APP_DOMAIN: string;
+};
+
+describe('Mentions Routes Integration Tests', () => {
+  let app: Hono<{ Bindings: TestBindings }>;
+
+  // Helper to clear tables
+  const clearTables = async () => {
+    await env.DB.exec('DELETE FROM mentions');
+    await env.DB.exec('DELETE FROM notes');
+  };
+
+  // Helper to insert a note directly via D1
+  const insertNote = async (note: {
+    id: string;
+    content: string;
+    parentId: string | null;
+    depth: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO notes (id, content, parent_id, depth, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    )
+      .bind(
+        note.id,
+        note.content,
+        note.parentId,
+        note.depth,
+        note.createdAt.toISOString(),
+        note.updatedAt.toISOString()
+      )
+      .run();
+  };
+
+  // Helper to insert a mention directly via D1
+  const insertMention = async (mention: {
+    id: string;
+    fromNoteId: string;
+    toNoteId: string;
+    position: number;
+    createdAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO mentions (id, from_note_id, to_note_id, position, created_at) VALUES (?, ?, ?, ?, ?)'
+    )
+      .bind(
+        mention.id,
+        mention.fromNoteId,
+        mention.toNoteId,
+        mention.position,
+        mention.createdAt.toISOString()
+      )
+      .run();
+  };
+
+  beforeEach(async () => {
+    // Clear database before each test
+    await clearTables();
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock authentication to succeed by default
+    mockAuthenticateRequest.mockResolvedValue({
+      isAuthenticated: true,
+      toAuth: () => ({ userId: 'test_user_123', sessionId: 'test_session_456' }),
+    });
+
+    // Create a fresh Hono app with the mentions routes
+    app = new Hono<{ Bindings: TestBindings }>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app.route('/api/notes', mentionsRoutes as any);
+    app.onError(errorHandler);
+  });
+
+  // Helper function to make requests with env bindings
+  const requestWithEnv = async (path: string, options: RequestInit = {}) => {
+    const testEnv: TestBindings = {
+      DB: env.DB,
+      CLERK_SECRET_KEY: 'sk_test_mock',
+      CLERK_PUBLISHABLE_KEY: 'pk_test_mock',
+      ALLOWED_ORIGINS: 'http://localhost:3000',
+      APP_DOMAIN: 'http://localhost:3000',
+    };
+    return app.request(path, options, testEnv);
+  };
+
+  describe('GET /api/notes/:id/mentions', () => {
+    it('should return empty array when no mentions exist', async () => {
+      const noteId = generateId();
+      const now = new Date();
+
+      await insertNote({
+        id: noteId,
+        content: 'A note with no mentions',
+        parentId: null,
+        depth: 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const res = await requestWithEnv(`/api/notes/${noteId}/mentions`, {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body).toMatchObject({
+        mentions: [],
+      });
+    });
+
+    it('should return mentions for a note', async () => {
+      const targetNoteId = generateId();
+      const mentioningNoteId = generateId();
+      const now = new Date();
+
+      // Create target note
+      await insertNote({
+        id: targetNoteId,
+        content: 'Target note',
+        parentId: null,
+        depth: 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // Create note that mentions target
+      await insertNote({
+        id: mentioningNoteId,
+        content: `Note mentioning @${targetNoteId}`,
+        parentId: null,
+        depth: 0,
+        createdAt: new Date(now.getTime() + 1000),
+        updatedAt: new Date(now.getTime() + 1000),
+      });
+
+      // Create mention record
+      await insertMention({
+        id: generateId(),
+        fromNoteId: mentioningNoteId,
+        toNoteId: targetNoteId,
+        position: 17,
+        createdAt: now,
+      });
+
+      const res = await requestWithEnv(`/api/notes/${targetNoteId}/mentions`, {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body.mentions).toHaveLength(1);
+      expect(body.mentions[0]).toMatchObject({
+        note: expect.objectContaining({
+          id: mentioningNoteId,
+          content: `Note mentioning @${targetNoteId}`,
+        }),
+        position: 17,
+      });
+    });
+
+    it('should return multiple mentions', async () => {
+      const targetNoteId = generateId();
+      const mentioningNote1Id = generateId();
+      const mentioningNote2Id = generateId();
+      const now = new Date();
+
+      // Create target note
+      await insertNote({
+        id: targetNoteId,
+        content: 'Target note',
+        parentId: null,
+        depth: 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // Create notes that mention target
+      await insertNote({
+        id: mentioningNote1Id,
+        content: `First mention @${targetNoteId}`,
+        parentId: null,
+        depth: 0,
+        createdAt: new Date(now.getTime() + 1000),
+        updatedAt: new Date(now.getTime() + 1000),
+      });
+
+      await insertNote({
+        id: mentioningNote2Id,
+        content: `Second mention @${targetNoteId}`,
+        parentId: null,
+        depth: 0,
+        createdAt: new Date(now.getTime() + 2000),
+        updatedAt: new Date(now.getTime() + 2000),
+      });
+
+      // Create mention records
+      await insertMention({
+        id: generateId(),
+        fromNoteId: mentioningNote1Id,
+        toNoteId: targetNoteId,
+        position: 14,
+        createdAt: now,
+      });
+
+      await insertMention({
+        id: generateId(),
+        fromNoteId: mentioningNote2Id,
+        toNoteId: targetNoteId,
+        position: 15,
+        createdAt: now,
+      });
+
+      const res = await requestWithEnv(`/api/notes/${targetNoteId}/mentions`, {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body.mentions).toHaveLength(2);
+    });
+
+    it('should return 404 for non-existent note', async () => {
+      const nonExistentId = generateId();
+
+      const res = await requestWithEnv(`/api/notes/${nonExistentId}/mentions`, {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(404);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body.error).toBe('Not Found');
+    });
+
+    it('should return 400 for invalid note ID format', async () => {
+      const res = await requestWithEnv('/api/notes/invalid-id/mentions', {
+        method: 'GET',
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/backend/tests/integration/search.routes.test.ts
+++ b/backend/tests/integration/search.routes.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Integration tests for search routes
+ *
+ * Tests the actual HTTP endpoints for searching notes by content and mention.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { env } from 'cloudflare:test';
+import { Hono } from 'hono';
+import type { ClerkClient } from '@clerk/backend';
+import searchRoutes from '../../src/api/routes/search';
+import { errorHandler } from '../../src/middleware/error';
+import { generateId } from '../../src/utils/id-generator';
+
+// NOTE: Mock the getClerkClient function
+const mockAuthenticateRequest = vi.fn();
+const mockClerkClient: Partial<ClerkClient> = {
+  authenticateRequest: mockAuthenticateRequest,
+};
+
+vi.mock('../../src/auth/clerk', () => ({
+  getClerkClient: () => mockClerkClient,
+}));
+
+type TestBindings = {
+  DB: D1Database;
+  CLERK_SECRET_KEY: string;
+  CLERK_PUBLISHABLE_KEY: string;
+  ALLOWED_ORIGINS: string;
+  APP_DOMAIN: string;
+};
+
+describe('Search Routes Integration Tests', () => {
+  let app: Hono<{ Bindings: TestBindings }>;
+
+  // Helper to clear tables
+  const clearTables = async () => {
+    await env.DB.exec('DELETE FROM search_index');
+    await env.DB.exec('DELETE FROM mentions');
+    await env.DB.exec('DELETE FROM notes');
+  };
+
+  // Helper to insert a note directly via D1
+  const insertNote = async (note: {
+    id: string;
+    content: string;
+    parentId: string | null;
+    depth: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO notes (id, content, parent_id, depth, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    )
+      .bind(
+        note.id,
+        note.content,
+        note.parentId,
+        note.depth,
+        note.createdAt.toISOString(),
+        note.updatedAt.toISOString()
+      )
+      .run();
+  };
+
+  // Helper to insert search index entry directly via D1
+  const insertSearchIndex = async (entry: {
+    noteId: string;
+    content: string;
+    tokens: string;
+    mentions: string | null;
+    updatedAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO search_index (note_id, content, tokens, mentions, updated_at) VALUES (?, ?, ?, ?, ?)'
+    )
+      .bind(
+        entry.noteId,
+        entry.content,
+        entry.tokens,
+        entry.mentions,
+        entry.updatedAt.toISOString()
+      )
+      .run();
+  };
+
+  // Helper to insert a mention directly via D1
+  const insertMention = async (mention: {
+    id: string;
+    fromNoteId: string;
+    toNoteId: string;
+    position: number;
+    createdAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO mentions (id, from_note_id, to_note_id, position, created_at) VALUES (?, ?, ?, ?, ?)'
+    )
+      .bind(
+        mention.id,
+        mention.fromNoteId,
+        mention.toNoteId,
+        mention.position,
+        mention.createdAt.toISOString()
+      )
+      .run();
+  };
+
+  beforeEach(async () => {
+    // Clear database before each test
+    await clearTables();
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock authentication to succeed by default
+    mockAuthenticateRequest.mockResolvedValue({
+      isAuthenticated: true,
+      toAuth: () => ({ userId: 'test_user_123', sessionId: 'test_session_456' }),
+    });
+
+    // Create a fresh Hono app with the search routes
+    app = new Hono<{ Bindings: TestBindings }>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app.route('/api/notes', searchRoutes as any);
+    app.onError(errorHandler);
+  });
+
+  // Helper function to make requests with env bindings
+  const requestWithEnv = async (path: string, options: RequestInit = {}) => {
+    const testEnv: TestBindings = {
+      DB: env.DB,
+      CLERK_SECRET_KEY: 'sk_test_mock',
+      CLERK_PUBLISHABLE_KEY: 'pk_test_mock',
+      ALLOWED_ORIGINS: 'http://localhost:3000',
+      APP_DOMAIN: 'http://localhost:3000',
+    };
+    return app.request(path, options, testEnv);
+  };
+
+  describe('GET /api/notes/search', () => {
+    describe('content search (type=content)', () => {
+      it('should return empty array when no matches', async () => {
+        const res = await requestWithEnv('/api/notes/search?q=nonexistent&type=content&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body).toMatchObject({
+          results: [],
+          total: 0,
+        });
+      });
+
+      it('should search notes by content', async () => {
+        const noteId = generateId();
+        const now = new Date();
+
+        await insertNote({
+          id: noteId,
+          content: 'Hello world this is a test note',
+          parentId: null,
+          depth: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        // Insert search index entry
+        await insertSearchIndex({
+          noteId,
+          content: 'Hello world this is a test note',
+          tokens: 'hello world this is a test note',
+          mentions: null,
+          updatedAt: now,
+        });
+
+        const res = await requestWithEnv('/api/notes/search?q=hello&type=content&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(1);
+        expect(body.results[0]).toMatchObject({
+          id: noteId,
+          content: 'Hello world this is a test note',
+        });
+        expect(body.total).toBe(1);
+      });
+
+      it('should search notes with multiple matches', async () => {
+        const note1Id = generateId();
+        const note2Id = generateId();
+        const now = new Date();
+
+        await insertNote({
+          id: note1Id,
+          content: 'TypeScript is awesome',
+          parentId: null,
+          depth: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        await insertNote({
+          id: note2Id,
+          content: 'I love TypeScript programming',
+          parentId: null,
+          depth: 0,
+          createdAt: new Date(now.getTime() + 1000),
+          updatedAt: new Date(now.getTime() + 1000),
+        });
+
+        await insertSearchIndex({
+          noteId: note1Id,
+          content: 'TypeScript is awesome',
+          tokens: 'typescript is awesome',
+          mentions: null,
+          updatedAt: now,
+        });
+
+        await insertSearchIndex({
+          noteId: note2Id,
+          content: 'I love TypeScript programming',
+          tokens: 'i love typescript programming',
+          mentions: null,
+          updatedAt: new Date(now.getTime() + 1000),
+        });
+
+        const res = await requestWithEnv('/api/notes/search?q=typescript&type=content&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(2);
+        expect(body.total).toBe(2);
+      });
+
+      it('should respect limit parameter', async () => {
+        const now = new Date();
+
+        // Create multiple notes
+        for (let i = 0; i < 5; i++) {
+          const noteId = generateId();
+          await insertNote({
+            id: noteId,
+            content: `Test note ${i}`,
+            parentId: null,
+            depth: 0,
+            createdAt: new Date(now.getTime() + i * 1000),
+            updatedAt: new Date(now.getTime() + i * 1000),
+          });
+
+          await insertSearchIndex({
+            noteId,
+            content: `Test note ${i}`,
+            tokens: `test note ${i}`,
+            mentions: null,
+            updatedAt: new Date(now.getTime() + i * 1000),
+          });
+        }
+
+        const res = await requestWithEnv('/api/notes/search?q=test&type=content&limit=2', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(2);
+      });
+
+      it('should default to content search when type is not specified', async () => {
+        const noteId = generateId();
+        const now = new Date();
+
+        await insertNote({
+          id: noteId,
+          content: 'Default search test',
+          parentId: null,
+          depth: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        await insertSearchIndex({
+          noteId,
+          content: 'Default search test',
+          tokens: 'default search test',
+          mentions: null,
+          updatedAt: now,
+        });
+
+        // No type parameter specified - should default to content
+        const res = await requestWithEnv('/api/notes/search?q=default&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(1);
+      });
+    });
+
+    describe('mention search (type=mention)', () => {
+      it('should search notes by mention', async () => {
+        const targetNoteId = generateId();
+        const mentioningNoteId = generateId();
+        const now = new Date();
+
+        // Create target note
+        await insertNote({
+          id: targetNoteId,
+          content: 'Target note',
+          parentId: null,
+          depth: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        // Create mentioning note
+        await insertNote({
+          id: mentioningNoteId,
+          content: `This mentions @${targetNoteId}`,
+          parentId: null,
+          depth: 0,
+          createdAt: new Date(now.getTime() + 1000),
+          updatedAt: new Date(now.getTime() + 1000),
+        });
+
+        // Create mention record
+        await insertMention({
+          id: generateId(),
+          fromNoteId: mentioningNoteId,
+          toNoteId: targetNoteId,
+          position: 14,
+          createdAt: now,
+        });
+
+        const res = await requestWithEnv(
+          `/api/notes/search?q=${targetNoteId}&type=mention&limit=20`,
+          { method: 'GET' }
+        );
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(1);
+        expect(body.results[0].id).toBe(mentioningNoteId);
+      });
+
+      it('should return empty when note has no mentions', async () => {
+        const noteId = generateId();
+        const now = new Date();
+
+        await insertNote({
+          id: noteId,
+          content: 'A note with no mentions',
+          parentId: null,
+          depth: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        const res = await requestWithEnv(`/api/notes/search?q=${noteId}&type=mention&limit=20`, {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.results).toHaveLength(0);
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when q parameter is missing', async () => {
+        const res = await requestWithEnv('/api/notes/search?type=content&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('should return 400 for empty q parameter', async () => {
+        const res = await requestWithEnv('/api/notes/search?q=&type=content&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('should return 400 for invalid type parameter', async () => {
+        const res = await requestWithEnv('/api/notes/search?q=test&type=invalid&limit=20', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('should return 400 for invalid limit parameter', async () => {
+        const res = await requestWithEnv('/api/notes/search?q=test&type=content&limit=0', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(400);
+      });
+
+      it('should return 400 for limit exceeding max', async () => {
+        const res = await requestWithEnv('/api/notes/search?q=test&type=content&limit=101', {
+          method: 'GET',
+        });
+
+        expect(res.status).toBe(400);
+      });
+    });
+  });
+});

--- a/backend/tests/integration/users.routes.test.ts
+++ b/backend/tests/integration/users.routes.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Integration tests for users routes
+ *
+ * Tests the actual HTTP endpoints for user synchronization.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { env } from 'cloudflare:test';
+import { Hono } from 'hono';
+import type { ClerkClient } from '@clerk/backend';
+import usersRoutes from '../../src/api/routes/users';
+import { errorHandler } from '../../src/middleware/error';
+import { generateId } from '../../src/utils/id-generator';
+
+// NOTE: Mock the getClerkClient function
+const mockAuthenticateRequest = vi.fn();
+const mockClerkClient: Partial<ClerkClient> = {
+  authenticateRequest: mockAuthenticateRequest,
+};
+
+vi.mock('../../src/auth/clerk', () => ({
+  getClerkClient: () => mockClerkClient,
+}));
+
+type TestBindings = {
+  DB: D1Database;
+  CLERK_SECRET_KEY: string;
+  CLERK_PUBLISHABLE_KEY: string;
+  ALLOWED_ORIGINS: string;
+  APP_DOMAIN: string;
+};
+
+describe('Users Routes Integration Tests', () => {
+  let app: Hono<{ Bindings: TestBindings }>;
+
+  // Helper to clear tables
+  const clearTables = async () => {
+    await env.DB.exec('DELETE FROM external_identities');
+    await env.DB.exec('DELETE FROM profiles');
+  };
+
+  // Helper to insert a profile directly via D1
+  const insertProfile = async (profile: {
+    id: string;
+    displayName: string;
+    bio: string | null;
+    avatarUrl: string | null;
+    preferences: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO profiles (id, display_name, bio, avatar_url, preferences, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    )
+      .bind(
+        profile.id,
+        profile.displayName,
+        profile.bio,
+        profile.avatarUrl,
+        profile.preferences,
+        Math.floor(profile.createdAt.getTime() / 1000),
+        Math.floor(profile.updatedAt.getTime() / 1000)
+      )
+      .run();
+  };
+
+  // Helper to insert an external identity directly via D1
+  const insertExternalIdentity = async (identity: {
+    id: string;
+    provider: string;
+    providerUserId: string;
+    profileId: string;
+    email: string | null;
+    emailVerified: boolean | null;
+    metadata: string | null;
+    providerCreatedAt: Date | null;
+    providerUpdatedAt: Date | null;
+    lastSyncedAt: Date;
+  }) => {
+    await env.DB.prepare(
+      'INSERT INTO external_identities (id, provider, provider_user_id, profile_id, email, email_verified, metadata, provider_created_at, provider_updated_at, last_synced_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    )
+      .bind(
+        identity.id,
+        identity.provider,
+        identity.providerUserId,
+        identity.profileId,
+        identity.email,
+        identity.emailVerified ? 1 : 0,
+        identity.metadata,
+        identity.providerCreatedAt ? Math.floor(identity.providerCreatedAt.getTime() / 1000) : null,
+        identity.providerUpdatedAt ? Math.floor(identity.providerUpdatedAt.getTime() / 1000) : null,
+        Math.floor(identity.lastSyncedAt.getTime() / 1000)
+      )
+      .run();
+  };
+
+  // Helper to query profiles
+  const queryProfile = async (id: string) => {
+    return env.DB.prepare('SELECT * FROM profiles WHERE id = ?')
+      .bind(id)
+      .first<{ id: string; display_name: string; avatar_url: string | null }>();
+  };
+
+  // Helper to query external identities
+  const queryIdentity = async (provider: string, providerUserId: string) => {
+    return env.DB.prepare(
+      'SELECT * FROM external_identities WHERE provider = ? AND provider_user_id = ?'
+    )
+      .bind(provider, providerUserId)
+      .first<{ id: string; profile_id: string; email: string | null }>();
+  };
+
+  beforeEach(async () => {
+    // Clear database before each test
+    await clearTables();
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock authentication to succeed by default
+    mockAuthenticateRequest.mockResolvedValue({
+      isAuthenticated: true,
+      toAuth: () => ({ userId: 'test_user_123', sessionId: 'test_session_456' }),
+    });
+
+    // Create a fresh Hono app with the users routes
+    app = new Hono<{ Bindings: TestBindings }>();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    app.route('/api/users', usersRoutes as any);
+    app.onError(errorHandler);
+  });
+
+  // Helper function to make requests with env bindings
+  const requestWithEnv = async (path: string, options: RequestInit = {}) => {
+    const testEnv: TestBindings = {
+      DB: env.DB,
+      CLERK_SECRET_KEY: 'sk_test_mock',
+      CLERK_PUBLISHABLE_KEY: 'pk_test_mock',
+      ALLOWED_ORIGINS: 'http://localhost:3000',
+      APP_DOMAIN: 'http://localhost:3000',
+    };
+    return app.request(path, options, testEnv);
+  };
+
+  describe('POST /api/users/sync', () => {
+    it('should create new user with profile and identity', async () => {
+      const res = await requestWithEnv('/api/users/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'CLERK',
+          providerUserId: 'clerk_user_123',
+          email: 'test@example.com',
+          emailVerified: true,
+          displayName: 'Test User',
+          avatarUrl: 'https://example.com/avatar.png',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body).toMatchObject({
+        synced: true,
+      });
+      expect(body.profileId).toBeDefined();
+      expect(body.identityId).toBeDefined();
+
+      // Verify profile was created
+      const profile = await queryProfile(body.profileId);
+      expect(profile).toBeDefined();
+      expect(profile?.display_name).toBe('Test User');
+      expect(profile?.avatar_url).toBe('https://example.com/avatar.png');
+
+      // Verify identity was created
+      const identity = await queryIdentity('CLERK', 'clerk_user_123');
+      expect(identity).toBeDefined();
+      expect(identity?.email).toBe('test@example.com');
+      expect(identity?.profile_id).toBe(body.profileId);
+    });
+
+    it('should update existing user', async () => {
+      // Create existing profile and identity
+      const profileId = generateId();
+      const identityId = generateId();
+      const now = new Date();
+
+      await insertProfile({
+        id: profileId,
+        displayName: 'Old Name',
+        bio: null,
+        avatarUrl: null,
+        preferences: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await insertExternalIdentity({
+        id: identityId,
+        provider: 'CLERK',
+        providerUserId: 'clerk_user_456',
+        profileId: profileId,
+        email: 'old@example.com',
+        emailVerified: false,
+        metadata: null,
+        providerCreatedAt: null,
+        providerUpdatedAt: null,
+        lastSyncedAt: now,
+      });
+
+      const res = await requestWithEnv('/api/users/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'CLERK',
+          providerUserId: 'clerk_user_456',
+          email: 'new@example.com',
+          emailVerified: true,
+          displayName: 'New Name',
+          avatarUrl: 'https://example.com/new-avatar.png',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body).toMatchObject({
+        synced: true,
+        profileId: profileId,
+        identityId: identityId,
+      });
+
+      // Verify profile was updated
+      const profile = await queryProfile(profileId);
+      expect(profile?.display_name).toBe('New Name');
+      expect(profile?.avatar_url).toBe('https://example.com/new-avatar.png');
+
+      // Verify identity was updated
+      const identity = await queryIdentity('CLERK', 'clerk_user_456');
+      expect(identity?.email).toBe('new@example.com');
+    });
+
+    it('should create user with minimal data', async () => {
+      const res = await requestWithEnv('/api/users/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'CLERK',
+          providerUserId: 'clerk_user_minimal',
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body.synced).toBe(true);
+
+      // Verify profile was created with default display name
+      const profile = await queryProfile(body.profileId);
+      expect(profile?.display_name).toBe('User');
+    });
+
+    it('should support different providers', async () => {
+      const providers = ['CLERK', 'AUTH0', 'GOOGLE', 'GITHUB'];
+
+      for (const provider of providers) {
+        const res = await requestWithEnv('/api/users/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider,
+            providerUserId: `${provider.toLowerCase()}_user_123`,
+          }),
+        });
+
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.synced).toBe(true);
+      }
+    });
+
+    describe('validation', () => {
+      it('should return 400 when provider is missing', async () => {
+        const res = await requestWithEnv('/api/users/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            providerUserId: 'user_123',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.error).toBe('Bad Request');
+      });
+
+      it('should return 400 when providerUserId is missing', async () => {
+        const res = await requestWithEnv('/api/users/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider: 'CLERK',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.error).toBe('Bad Request');
+      });
+
+      it('should return 400 for invalid provider', async () => {
+        const res = await requestWithEnv('/api/users/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            provider: 'INVALID_PROVIDER',
+            providerUserId: 'user_123',
+          }),
+        });
+
+        expect(res.status).toBe(400);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const body = (await res.json()) as any;
+        expect(body.error).toBe('Bad Request');
+        expect(body.message).toContain('Invalid provider');
+      });
+    });
+
+    it('should handle metadata field', async () => {
+      const metadata = { custom_field: 'value', number: 42 };
+
+      const res = await requestWithEnv('/api/users/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'CLERK',
+          providerUserId: 'clerk_user_with_metadata',
+          metadata,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body = (await res.json()) as any;
+      expect(body.synced).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add integration tests for mentions routes (GET /api/notes/:id/mentions)
- Add integration tests for search routes (GET /api/notes/search)
- Add integration tests for users routes (POST /api/users/sync)
- Fix mentions.ts to properly handle ResultAsync error checking
- Fix users.ts to use c.get('db') for consistency with other routes
- Add integration-tests job to GitHub Actions PR workflow

## Test plan
- [x] All integration tests pass locally (42 passed)
- [x] Lint passes
- [x] Typecheck passes
- [ ] CI pipeline runs integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)