### PR TITLE
feat: テキストインプットの統一

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
 import { TextInput } from '@/components/ui/text-input';
-import { cn } from '@/lib/utils';
 import { useFocus } from '@/store/focus.context';
 
 interface NoteEditorProps {

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { TextInput } from '@/components/ui/text-input';
 import { cn } from '@/lib/utils';
 import { useFocus } from '@/store/focus.context';
 
@@ -61,9 +61,7 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
   }, [autoFocus, initialContent]);
 
   const handleContentChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const newContent = e.target.value;
-
+    (newContent: string) => {
       if (newContent.length > maxLength) {
         setError(`Content exceeds ${maxLength} characters`);
         return;
@@ -71,22 +69,28 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
 
       setContent(newContent);
       setError(null);
-      setCursorPosition(e.target.selectionStart);
 
-      // NOTE: Detect @ mention trigger
-      if (onMentionTrigger) {
-        const beforeCursor = newContent.slice(0, e.target.selectionStart);
-        const mentionMatch = beforeCursor.match(/@(\w*)$/);
-        if (mentionMatch) {
-          onMentionTrigger(mentionMatch[1]);
+      // NOTE: Get cursor position from textarea ref
+      if (textareaRef.current) {
+        setCursorPosition(textareaRef.current.selectionStart);
+
+        // NOTE: Detect @ mention trigger
+        if (onMentionTrigger) {
+          const beforeCursor = newContent.slice(0, textareaRef.current.selectionStart);
+          const mentionMatch = beforeCursor.match(/@(\w*)$/);
+          if (mentionMatch) {
+            onMentionTrigger(mentionMatch[1]);
+          }
         }
       }
     },
     [maxLength, onMentionTrigger]
   );
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: React.FormEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
 
     if (!content.trim()) {
       setError('Note content cannot be empty');
@@ -121,19 +125,13 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      // NOTE: Submit with Cmd/Ctrl + Enter
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        handleSubmit(e as React.FormEvent);
-      }
-
       // NOTE: Cancel with Escape
       if (e.key === 'Escape' && onCancel) {
         e.preventDefault();
         onCancel();
       }
     },
-    [handleSubmit, onCancel]
+    [onCancel]
   );
 
   const insertMention = useCallback(
@@ -183,65 +181,38 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-3">
-        <div className="space-y-2">
-          <Textarea
-            ref={textareaRef}
-            value={content}
-            onChange={handleContentChange}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            className={cn(
-              'min-h-20 resize-none',
-              error && 'border-destructive focus-visible:ring-destructive'
-            )}
-            disabled={isSubmitting}
-            rows={3}
-            data-testid="note-editor-textarea"
-          />
+      <form onSubmit={handleSubmit}>
+        <TextInput
+          ref={textareaRef}
+          value={content}
+          onChange={handleContentChange}
+          onSubmit={handleSubmit}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={isSubmitting}
+          autoFocus={autoFocus}
+        />
 
-          <div className="flex items-center justify-between">
-            <div className="text-muted-foreground text-xs" data-testid="note-editor-char-count">
-              <span className={cn(content.length > maxLength * 0.9 && 'text-warning')}>
-                {content.length} / {maxLength}
-              </span>
-            </div>
-
-            <div className="flex items-center gap-2">
-              {onCancel && (
-                <Button
-                  type="button"
-                  onClick={onCancel}
-                  variant="outline"
-                  size="sm"
-                  disabled={isSubmitting}
-                  data-testid="note-editor-cancel"
-                >
-                  Cancel
-                </Button>
-              )}
-
-              <Button
-                type="submit"
-                size="sm"
-                disabled={isSubmitting || !content.trim() || content.length > maxLength}
-                data-testid="note-editor-submit"
-              >
-                {isSubmitting ? 'Saving...' : parentNote ? 'Reply' : 'Create Note'}
-              </Button>
-            </div>
+        {onCancel && (
+          <div className="flex items-center gap-2 mt-2">
+            <Button
+              type="button"
+              onClick={onCancel}
+              variant="outline"
+              size="sm"
+              disabled={isSubmitting}
+              data-testid="note-editor-cancel"
+            >
+              Cancel
+            </Button>
           </div>
+        )}
 
-          {error && (
-            <div className="text-destructive text-sm" data-testid="note-editor-error">
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="text-muted-foreground text-xs">
-          <span>Tip: Use @ID to mention other notes • Press Cmd/Ctrl+Enter to submit</span>
-        </div>
+        {error && (
+          <div className="text-destructive text-sm mt-2" data-testid="note-editor-error">
+            {error}
+          </div>
+        )}
       </form>
     </div>
   );

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -3,9 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { useFocus } from '@/store/focus.context';
 import {
   X,
-  Send,
-  Smile,
-  Paperclip,
   MoreVertical,
   Trash2,
   Bookmark,
@@ -13,10 +10,10 @@ import {
   Edit,
   Pin,
   ArrowLeft,
+  MessageSquare,
 } from 'lucide-react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   DropdownMenu,
@@ -27,6 +24,7 @@ import {
 import { getRelativeTime } from '@/lib/utils';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import NoteEditor from './NoteEditor';
+import { TextInput } from '@/components/ui/text-input';
 
 interface ThreadViewProps {
   rootNote: Note;
@@ -87,13 +85,17 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
 
   const handleReply = async () => {
     if (!replyContent.trim()) return;
-    await onReply(rootNote.id, replyContent);
-    setReplyContent('');
+    try {
+      await onReply(rootNote.id, replyContent);
+      setReplyContent('');
 
-    // NOTE: Smart auto-focus - re-focus for next reply
-    setTimeout(() => {
-      replyInputRef.current?.focus();
-    }, 0);
+      // NOTE: Smart auto-focus - re-focus for next reply
+      setTimeout(() => {
+        replyInputRef.current?.focus();
+      }, 0);
+    } catch (error) {
+      console.error('Failed to reply:', error);
+    }
   };
 
   const handleEdit = async (noteId: string, content: string) => {
@@ -316,7 +318,7 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
             {replies.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-8 text-center">
                 <div className="mb-4 rounded-full bg-accent p-4">
-                  <Smile className="h-8 w-8 text-muted-foreground/50" />
+                  <MessageSquare className="h-8 w-8 text-muted-foreground/50" />
                 </div>
                 <p className="font-medium text-foreground text-sm">No replies yet</p>
                 <p className="text-muted-foreground text-xs">Be the first to reply to this note</p>
@@ -464,41 +466,14 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
 
       {/* Reply Input */}
       <div className="border-t border-border p-4 flex-shrink-0" data-testid="thread-reply-input">
-        <div className="flex items-end gap-2">
-          <div className="flex-1 rounded-lg border border-input bg-card">
-            <Textarea
-              ref={replyInputRef}
-              placeholder="Reply... (Cmd/Ctrl+Enter to send)"
-              value={replyContent}
-              onChange={(e) => setReplyContent(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  handleReply();
-                }
-              }}
-              className="border-0 bg-transparent focus-visible:ring-0 min-h-[40px] max-h-[120px] resize-none"
-              rows={1}
-              data-testid="thread-reply-textarea"
-            />
-            <div className="flex items-center gap-1 px-3 pb-2">
-              <Button size="icon" variant="ghost" className="h-7 w-7">
-                <Paperclip className="h-4 w-4" />
-              </Button>
-              <Button size="icon" variant="ghost" className="h-7 w-7">
-                <Smile className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-          <Button
-            size="icon"
-            className="h-10 w-10 shrink-0"
-            onClick={handleReply}
-            data-testid="thread-reply-submit"
-          >
-            <Send className="h-4 w-4" />
-          </Button>
-        </div>
+        <TextInput
+          ref={replyInputRef}
+          value={replyContent}
+          onChange={setReplyContent}
+          onSubmit={handleReply}
+          placeholder="Reply... (Cmd/Ctrl+Enter to send)"
+          autoFocus={false}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/ui/text-input.tsx
+++ b/frontend/src/components/ui/text-input.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useRef, useCallback, useEffect, forwardRef } from 'react';
+import { Paperclip, Smile, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface TextInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  className?: string;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
+  (
+    {
+      value,
+      onChange,
+      onSubmit,
+      placeholder = 'Type a message...',
+      disabled = false,
+      autoFocus = false,
+      className,
+      onKeyDown,
+    },
+    ref
+  ) => {
+    const internalRef = useRef<HTMLTextAreaElement>(null);
+    const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        onChange(e.target.value);
+      },
+      [onChange]
+    );
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (onKeyDown) {
+          onKeyDown(e);
+        }
+
+        // NOTE: Submit with Cmd/Ctrl + Enter
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          onSubmit();
+        }
+      },
+      [onKeyDown, onSubmit]
+    );
+
+    // NOTE: Auto-resize textarea based on content (max 3 rows)
+    useEffect(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+
+      textarea.style.height = 'auto';
+      const scrollHeight = textarea.scrollHeight;
+      const lineHeight = parseInt(getComputedStyle(textarea).lineHeight);
+      const maxHeight = lineHeight * 3;
+
+      textarea.style.height = `${Math.min(scrollHeight, maxHeight)}px`;
+    }, [value, textareaRef]);
+
+    return (
+      <div className={cn('flex items-end gap-2', className)}>
+        <div className="flex-1 rounded-lg border border-input bg-card">
+          <Textarea
+            ref={textareaRef}
+            placeholder={placeholder}
+            value={value}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            disabled={disabled}
+            autoFocus={autoFocus}
+            className="border-0 bg-transparent focus-visible:ring-0 min-h-[72px] resize-none"
+            rows={3}
+          />
+          <div className="flex items-center gap-1 px-3 pb-2">
+            <Button size="icon" variant="ghost" className="h-7 w-7" type="button">
+              <Paperclip className="h-4 w-4" />
+            </Button>
+            <Button size="icon" variant="ghost" className="h-7 w-7" type="button">
+              <Smile className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+        <Button
+          size="icon"
+          className="h-10 w-10 shrink-0"
+          onClick={onSubmit}
+          disabled={disabled || !value.trim()}
+          type="button"
+        >
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
+);
+
+TextInput.displayName = 'TextInput';
+
+export default TextInput;

--- a/frontend/src/components/ui/text-input.tsx
+++ b/frontend/src/components/ui/text-input.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect, forwardRef } from 'react';
+import React, { useRef, useCallback, useEffect, forwardRef } from 'react';
 import { Paperclip, Smile, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';


### PR DESCRIPTION
## Summary
メッセージ用とスレッド用の2つのテキストインプットを統一されたデザインに変更しました。

## Changes
- ✨ 新規作成: `TextInput` 共通コンポーネント (`frontend/src/components/ui/text-input.tsx`)
- 🔄 更新: `ThreadView` でTextInputコンポーネントを使用
- 🔄 更新: `NoteEditor` でTextInputコンポーネントを使用

## Design Specifications
- ファイルアイコン（Paperclip）と絵文字アイコン（Smile）
- Sendアイコンの送信ボタン
- 文字カウント表示なし
- 初期3行分の高さ、入力に応じて自動拡大（最大3行）
- Cmd/Ctrl+Enterで送信

## Test plan
- [x] TypeScript型チェック: パス
- [x] Prettierフォーマット: 完了
- [x] フロントエンドビルド: 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)