### PR TITLE
feat: implement hidden chat feature (backend)

### DIFF
--- a/backend/drizzle/0002_add_is_hidden_to_notes.sql
+++ b/backend/drizzle/0002_add_is_hidden_to_notes.sql
@@ -1,0 +1,5 @@
+-- Migration: Add is_hidden column to notes table
+-- This enables hidden chat functionality where notes can be marked as hidden
+-- and only displayed when the user enables the "Show Hidden Notes" setting
+
+ALTER TABLE `notes` ADD COLUMN `is_hidden` integer DEFAULT 0 NOT NULL;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1762586340000,
       "tag": "0001_split_user_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1765600000000,
+      "tag": "0002_add_is_hidden_to_notes",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/routes/notes.ts
+++ b/backend/src/api/routes/notes.ts
@@ -28,9 +28,10 @@ const app = createRouter()
     const noteService = createNoteService({ db });
 
     const { limit, offset } = c.req.valid('query');
+    const includeHidden = c.req.query('includeHidden') === 'true';
 
     return await noteService
-      .getRootNotes(limit, offset)
+      .getRootNotes(limit, offset, includeHidden)
       .map((d) => ({
         notes: d.notes.map(serialize),
         total: d.total,

--- a/backend/src/errors/domain-errors.ts
+++ b/backend/src/errors/domain-errors.ts
@@ -39,6 +39,10 @@ export interface DepthLimitExceededError extends DomainError {
   readonly maxDepth: number;
 }
 
+export interface InvalidHiddenReplyError extends DomainError {
+  readonly _tag: 'InvalidHiddenReplyError';
+}
+
 // Not Found Errors (404 Not Found)
 export interface NoteNotFoundError extends DomainError {
   readonly _tag: 'NoteNotFoundError';
@@ -63,6 +67,7 @@ export type NoteError =
   | ContentEmptyError
   | CircularReferenceError
   | DepthLimitExceededError
+  | InvalidHiddenReplyError
   | NoteNotFoundError
   | ParentNoteNotFoundError
   | DatabaseError;
@@ -105,6 +110,11 @@ export const depthLimitExceededError = (maxDepth: number): DepthLimitExceededErr
   maxDepth,
 });
 
+export const invalidHiddenReplyError = (): InvalidHiddenReplyError => ({
+  _tag: 'InvalidHiddenReplyError',
+  message: 'Only root notes can be marked as hidden. Replies inherit hidden status from parent.',
+});
+
 export const noteNotFoundError = (noteId: string): NoteNotFoundError => ({
   _tag: 'NoteNotFoundError',
   message: `Note with id '${noteId}' not found`,
@@ -135,7 +145,8 @@ export const isClientError = (error: NoteError): boolean =>
   error._tag === 'ContentTooLongError' ||
   error._tag === 'ContentEmptyError' ||
   error._tag === 'CircularReferenceError' ||
-  error._tag === 'DepthLimitExceededError';
+  error._tag === 'DepthLimitExceededError' ||
+  error._tag === 'InvalidHiddenReplyError';
 
 // HTTP status code mapping
 export const errorToStatusCode = (error: NoteError): 400 | 404 | 500 => {
@@ -148,6 +159,7 @@ export const errorToStatusCode = (error: NoteError): 400 | 404 | 500 => {
     case 'ContentEmptyError':
     case 'CircularReferenceError':
     case 'DepthLimitExceededError':
+    case 'InvalidHiddenReplyError':
       return 400;
     case 'DatabaseError':
       return 500;

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -9,6 +9,7 @@ export const createNoteSchema = z.object({
     .string()
     .regex(new RegExp(`^[A-Za-z0-9]{${ID_LENGTH}}$`))
     .optional(),
+  isHidden: z.boolean().optional(),
 });
 
 export const updateNoteSchema = z.object({

--- a/backend/src/models/note.schema.ts
+++ b/backend/src/models/note.schema.ts
@@ -18,6 +18,7 @@ export const notes = sqliteTable('notes', {
     .notNull()
     .default(sql`(unixepoch())`),
   depth: integer('depth').notNull().default(0),
+  isHidden: integer('is_hidden', { mode: 'boolean' }).notNull().default(false),
 });
 
 export type Note = typeof notes.$inferSelect;

--- a/backend/src/services/note/types.ts
+++ b/backend/src/services/note/types.ts
@@ -16,6 +16,7 @@ import type { NoteError } from '../../errors/domain-errors';
 export interface CreateNoteInput {
   readonly content: string;
   readonly parentId?: string;
+  readonly isHidden?: boolean;
 }
 
 /** ノート更新のための入力データ */
@@ -45,6 +46,7 @@ export interface ValidatedNoteData {
   readonly parentId?: string;
   readonly depth: number;
   readonly mentionIds: string[];
+  readonly isHidden: boolean;
 }
 
 // ==========================================
@@ -66,7 +68,8 @@ export interface NoteServiceHandle {
   /** ルートノートを取得 */
   readonly getRootNotes: (
     limit?: number,
-    offset?: number
+    offset?: number,
+    includeHidden?: boolean
   ) => ResultAsync<PaginatedNotes, NoteError>;
   /** ノートを更新 */
   readonly updateNote: (id: string, input: UpdateNoteInput) => ResultAsync<Note, NoteError>;

--- a/backend/src/services/note/validation.ts
+++ b/backend/src/services/note/validation.ts
@@ -15,6 +15,7 @@ import {
   parentNoteNotFoundError,
   depthLimitExceededError,
   circularReferenceError,
+  invalidHiddenReplyError,
 } from '../../errors/domain-errors';
 
 // ==========================================
@@ -96,4 +97,18 @@ export const calculateDepthFromParent = (
   if (!parent) return err(parentNoteNotFoundError(parentId));
   if (parent.depth >= 1) return err(depthLimitExceededError(1));
   return ok(1);
+};
+
+/**
+ * isHiddenフィールドのバリデーション
+ * リプライ（parentIdあり）でisHidden=trueを設定しようとした場合はエラー
+ */
+export const validateIsHidden = (
+  isHidden: boolean | undefined,
+  parentId?: string
+): Result<void, NoteError> => {
+  if (isHidden === true && parentId !== undefined) {
+    return err(invalidHiddenReplyError());
+  }
+  return ok(undefined);
 };

--- a/frontend/src/services/note.service.ts
+++ b/frontend/src/services/note.service.ts
@@ -18,6 +18,7 @@ interface NoteWithThreadResponse {
     createdAt: string;
     updatedAt: string;
     depth: number;
+    isHidden: boolean;
     replyCount?: number;
   };
   thread: Array<{
@@ -27,6 +28,7 @@ interface NoteWithThreadResponse {
     createdAt: string;
     updatedAt: string;
     depth: number;
+    isHidden: boolean;
     replyCount?: number;
   }>;
 }
@@ -34,6 +36,7 @@ interface NoteWithThreadResponse {
 interface CreateNoteDto {
   content: string;
   parentId?: string;
+  isHidden?: boolean;
 }
 
 interface UpdateNoteDto {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -8,6 +8,7 @@ export interface Note {
   createdAt: string; // ISO 8601 string
   updatedAt: string; // ISO 8601 string
   depth: number; // Thread depth (0 for root)
+  isHidden: boolean; // Whether note is hidden (only shown when setting enabled)
   replyCount?: number; // Number of direct replies (optional, included in list views)
   tags?: string[]; // Optional tags for categorization (UI-only for now)
   images?: string[]; // Optional image URLs (UI-only for now)
@@ -35,6 +36,7 @@ export interface SearchIndex {
 export interface CreateNoteRequest {
   content: string;
   parentId?: string;
+  isHidden?: boolean;
 }
 
 export interface UpdateNoteRequest {


### PR DESCRIPTION
## Summary

Implement the backend infrastructure for the hidden chat feature, which allows users to mark root notes as hidden. Hidden notes are not displayed by default and can only be viewed when the user enables the "Show Hidden Notes" setting.

### Key Features

- ✅ **Parent-only Hidden**: Only root notes can be explicitly marked as hidden
- ✅ **Automatic Inheritance**: Replies automatically inherit their parent's hidden status  
- ✅ **Server-side Filtering**: Hidden notes excluded by default via `includeHidden` query parameter
- ✅ **Validation**: Returns 400 error if attempting to set `isHidden=true` on a reply
- ✅ **Type Safety**: Full TypeScript support across all layers

## Changes

### Database Schema
- Added `isHidden` boolean field to `notes` table (backend/src/models/note.schema.ts:21)
- Created migration: `0002_add_is_hidden_to_notes.sql`

### Type Definitions
- Updated `Note` interface with `isHidden: boolean` (shared/types/index.ts:11)
- Updated `CreateNoteRequest` with `isHidden?: boolean` (shared/types/index.ts:39)
- Added `includeHidden` parameter to service types (backend/src/services/note/types.ts:72)

### Validation & Error Handling
- Created `InvalidHiddenReplyError` type (backend/src/errors/domain-errors.ts:42-44)
- Added `validateIsHidden()` function (backend/src/services/note/validation.ts:102-114)
- Error message: "Only root notes can be marked as hidden. Replies inherit hidden status from parent."

### Service Layer
- Updated `createNote()` with isHidden validation and thread inheritance (backend/src/services/note/note.service.ts:67-97)
- Updated `getRootNotes()` to support `includeHidden` parameter (backend/src/services/note/note.service.ts:169-177)
- Replies automatically inherit parent's `isHidden` status

### Repository Layer  
- Updated `findRootNotes()` with filtering logic (backend/src/repositories/note.repository.ts:119-134)
  - `includeHidden=false` (default): `WHERE parent_id IS NULL AND is_hidden = false`
  - `includeHidden=true`: `WHERE parent_id IS NULL`
- Updated `countRootNotes()` with same filtering

### API Routes
- Updated `POST /api/notes` to accept `isHidden` in request body
- Updated `GET /api/notes` to support `?includeHidden=true` query parameter (backend/src/api/routes/notes.ts:31,34)
- Validation middleware updated (backend/src/middleware/validation.ts:12)

### Frontend Type Updates
- Updated `NoteWithThreadResponse` interface with `isHidden` field
- Updated `CreateNoteDto` with `isHidden` parameter

## Testing

- ✅ All 71 backend tests pass
- ✅ Lint, typecheck, and format checks pass
- ✅ Database migration applied successfully

## Implementation Details

**Thread Inheritance Logic:**
When creating a reply, the service automatically fetches the parent note and inherits its `isHidden` status. This ensures that entire threads maintain consistent visibility.

**Validation:**
The `validateIsHidden()` function ensures that clients cannot explicitly set `isHidden=true` on replies, preventing inconsistent state.

## Next Steps

Frontend implementation (separate PR):
1. Add checkbox to TextInput component  
2. Create settings store for `showHiddenNotes` toggle
3. Pass `includeHidden` to API calls based on user settings
4. Create settings page UI
5. Add visual indicators for hidden notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)