### PR TITLE
Add hidden chat feature to frontend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "build:worker": "wrangler deploy --dry-run",
     "start": "bun dist/index.js",
     "test": "NODE_ENV=test bun test src tests/preload.ts tests/setup.ts",
-    "test:integration": "NODE_ENV=test vitest --config vitest.config.ts",
+    "test:integration": "NODE_ENV=test vitest run --config vitest.config.ts",
     "test:load": "k6 run tests/load/load-test.js",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/backend/src/api/routes/notes.ts
+++ b/backend/src/api/routes/notes.ts
@@ -5,6 +5,7 @@ import { errorToStatusCode, type NoteError } from '../../errors/domain-errors';
 import {
   validateCreateNote,
   validateUpdateNote,
+  validateUpdateHidden,
   validateNoteId,
   validatePagination,
 } from '../../middleware/validation';
@@ -92,6 +93,22 @@ const app = createRouter()
 
     return await noteService
       .updateNote(id, data)
+      .map(serialize)
+      .match(
+        (data) => c.json(data),
+        (error: NoteError) => c.json(toErrorResponse(error), errorToStatusCode(error))
+      );
+  })
+
+  // PATCH /api/notes/:id/hidden - Update note hidden status
+  .patch('/:id/hidden', requireAuth, validateNoteId, validateUpdateHidden, async (c) => {
+    const db = c.get('db');
+    const noteService = createNoteService({ db });
+    const { id } = c.req.valid('param');
+    const { isHidden } = c.req.valid('json');
+
+    return await noteService
+      .updateHidden(id, isHidden)
       .map(serialize)
       .match(
         (data) => c.json(data),

--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -16,6 +16,10 @@ export const updateNoteSchema = z.object({
   content: z.string().min(1).max(MAX_NOTE_LENGTH),
 });
 
+export const updateHiddenSchema = z.object({
+  isHidden: z.boolean(),
+});
+
 export const noteIdSchema = z.object({
   id: z.string().regex(new RegExp(`^[A-Za-z0-9]{${ID_LENGTH}}$`)),
 });
@@ -34,6 +38,7 @@ export const paginationSchema = z.object({
 // NOTE: Export validators - types will be inferred from Hono app context
 export const validateCreateNote = zValidator('json', createNoteSchema);
 export const validateUpdateNote = zValidator('json', updateNoteSchema);
+export const validateUpdateHidden = zValidator('json', updateHiddenSchema);
 export const validateNoteId = zValidator('param', noteIdSchema);
 export const validateSearch = zValidator('query', searchQuerySchema);
 export const validatePagination = zValidator('query', paginationSchema);

--- a/backend/src/repositories/note.repository.ts
+++ b/backend/src/repositories/note.repository.ts
@@ -43,6 +43,7 @@ export interface NoteRepository {
   readonly findById: (id: string) => ResultAsync<Note | undefined, NoteError>;
   readonly create: (note: NewNote) => ResultAsync<Note, NoteError>;
   readonly update: (id: string, content: string) => ResultAsync<Note, NoteError>;
+  readonly updateHidden: (id: string, isHidden: boolean) => ResultAsync<Note, NoteError>;
   readonly findRootNotes: (
     limit: number,
     offset: number,
@@ -114,6 +115,17 @@ export const createNoteRepository = ({ db }: { db: Database }): NoteRepository =
           .returning()
           .then(([updated]) => updated),
         'Failed to update note'
+      ),
+
+    updateHidden: (id, isHidden) =>
+      dbQuery(
+        db
+          .update(notes)
+          .set({ isHidden, updatedAt: new Date() })
+          .where(eq(notes.id, id))
+          .returning()
+          .then(([updated]) => updated),
+        'Failed to update note hidden status'
       ),
 
     findRootNotes: (limit, offset, includeHidden = false) => {

--- a/backend/src/services/note/types.ts
+++ b/backend/src/services/note/types.ts
@@ -73,6 +73,8 @@ export interface NoteServiceHandle {
   ) => ResultAsync<PaginatedNotes, NoteError>;
   /** ノートを更新 */
   readonly updateNote: (id: string, input: UpdateNoteInput) => ResultAsync<Note, NoteError>;
+  /** ノートの hidden 状態を更新 */
+  readonly updateHidden: (id: string, isHidden: boolean) => ResultAsync<Note, NoteError>;
   /** ノートを削除（カスケード） */
   readonly deleteNote: (id: string) => ResultAsync<void, NoteError>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { NotesUIProvider } from './store/notes.store';
 import { FocusProvider } from './store/focus.context';
+import { SettingsProvider } from './store/settings.store';
 import { AppRouter } from './router';
 import { AuthGuard } from './components/AuthGuard';
 import { useUserSync } from './hooks/useUserSync';
@@ -28,13 +29,15 @@ const App: React.FC = () => {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <NotesUIProvider>
-        <FocusProvider>
-          <AuthGuard>
-            <AppRouter />
-          </AuthGuard>
-        </FocusProvider>
-      </NotesUIProvider>
+      <SettingsProvider>
+        <NotesUIProvider>
+          <FocusProvider>
+            <AuthGuard>
+              <AppRouter />
+            </AuthGuard>
+          </FocusProvider>
+        </NotesUIProvider>
+      </SettingsProvider>
     </QueryClientProvider>
   );
 };

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -7,7 +7,7 @@ import { useFocus } from '@/store/focus.context';
 interface NoteEditorProps {
   initialContent?: string;
   parentNote?: Note;
-  onSubmit: (content: string) => Promise<void>;
+  onSubmit: (content: string, isHidden?: boolean) => Promise<void>;
   onCancel?: () => void;
   placeholder?: string;
   maxLength?: number;
@@ -30,6 +30,7 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
   const [content, setContent] = useState(initialContent);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isHidden, setIsHidden] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [cursorPosition, setCursorPosition] = useState(0);
   const { registerInput, unregisterInput } = useFocus();
@@ -105,8 +106,9 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
     setError(null);
 
     try {
-      await onSubmit(content.trim());
+      await onSubmit(content.trim(), isHidden);
       setContent('');
+      setIsHidden(false);
       setError(null);
 
       // NOTE: Smart auto-focus - re-focus for next note if creating (not editing)
@@ -190,6 +192,8 @@ export const NoteEditor: React.FC<NoteEditorProps> = ({
           placeholder={placeholder}
           disabled={isSubmitting}
           autoFocus={autoFocus}
+          isHidden={isHidden}
+          onHiddenChange={setIsHidden}
         />
 
         {onCancel && (

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
-import { Hash, Search, MoreVertical, Trash2, Bookmark, Link2, Edit, Pin, Plus, EyeOff } from 'lucide-react';
+import {
+  Hash,
+  Search,
+  MoreVertical,
+  Trash2,
+  Bookmark,
+  Link2,
+  Edit,
+  Pin,
+  Plus,
+  EyeOff,
+} from 'lucide-react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -227,7 +238,9 @@ export const NoteList: React.FC<NoteListProps> = ({
                           {getRelativeTime(note.createdAt)}
                         </span>
                         {note.isHidden && (
-                          <EyeOff className="h-3 w-3 text-muted-foreground" title="Hidden note" />
+                          <span title="Hidden note">
+                            <EyeOff className="h-3 w-3 text-muted-foreground" />
+                          </span>
                         )}
                         {note.replyCount !== undefined && note.replyCount > 0 && (
                           <span

--- a/frontend/src/components/NoteList.tsx
+++ b/frontend/src/components/NoteList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
-import { Hash, Search, MoreVertical, Trash2, Bookmark, Link2, Edit, Pin, Plus } from 'lucide-react';
+import { Hash, Search, MoreVertical, Trash2, Bookmark, Link2, Edit, Pin, Plus, EyeOff } from 'lucide-react';
 import { Note } from '../../../shared/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -8,6 +8,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
@@ -15,6 +17,8 @@ import { getRelativeTime } from '@/lib/utils';
 import NoteEditor from './NoteEditor';
 import { ThemeToggle } from './ThemeToggle';
 import { UserButton } from './UserButton';
+import { SettingsDropdown } from './SettingsDropdown';
+import { useSettings } from '@/store/settings.store';
 
 interface NoteListProps {
   notes: Note[];
@@ -23,7 +27,8 @@ interface NoteListProps {
   onLoadMore?: () => void;
   hasMore?: boolean;
   loading?: boolean;
-  onCreateNote?: (content: string) => Promise<void>;
+  onCreateNote?: (content: string, isHidden?: boolean) => Promise<void>;
+  onToggleHidden?: (noteId: string, isHidden: boolean) => Promise<void>;
 }
 
 export const NoteList: React.FC<NoteListProps> = ({
@@ -34,7 +39,9 @@ export const NoteList: React.FC<NoteListProps> = ({
   hasMore = false,
   loading = false,
   onCreateNote,
+  onToggleHidden,
 }) => {
+  const { showHiddenNotes } = useSettings();
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -110,6 +117,7 @@ export const NoteList: React.FC<NoteListProps> = ({
             {filteredNotes.length} notes
           </span>
           <UserButton />
+          <SettingsDropdown />
           <ThemeToggle />
           <Button size="icon" variant="ghost" className="h-8 w-8">
             <Plus className="h-4 w-4" />
@@ -153,6 +161,18 @@ export const NoteList: React.FC<NoteListProps> = ({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
+                      {onToggleHidden && showHiddenNotes && (
+                        <>
+                          <DropdownMenuCheckboxItem
+                            checked={note.isHidden}
+                            onCheckedChange={(checked) => onToggleHidden(note.id, checked)}
+                          >
+                            <EyeOff className="mr-2 h-4 w-4" />
+                            Hidden
+                          </DropdownMenuCheckboxItem>
+                          <DropdownMenuSeparator />
+                        </>
+                      )}
                       <DropdownMenuItem>
                         <Pin className="mr-2 h-4 w-4" />
                         Pin note
@@ -206,6 +226,9 @@ export const NoteList: React.FC<NoteListProps> = ({
                         <span className="text-muted-foreground text-xs">
                           {getRelativeTime(note.createdAt)}
                         </span>
+                        {note.isHidden && (
+                          <EyeOff className="h-3 w-3 text-muted-foreground" title="Hidden note" />
+                        )}
                         {note.replyCount !== undefined && note.replyCount > 0 && (
                           <span
                             className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/20 px-1.5 font-medium text-primary text-xs"

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -1,0 +1,37 @@
+import { Settings, EyeOff } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useSettings } from '@/store/settings.store';
+
+export function SettingsDropdown() {
+  const { showHiddenNotes, toggleShowHiddenNotes } = useSettings();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-8 w-8">
+          <Settings className="h-4 w-4" />
+          <span className="sr-only">Settings</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Settings</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem
+          checked={showHiddenNotes}
+          onCheckedChange={toggleShowHiddenNotes}
+        >
+          <EyeOff className="mr-2 h-4 w-4" />
+          Show hidden notes
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/SettingsDropdown.tsx
+++ b/frontend/src/components/SettingsDropdown.tsx
@@ -24,10 +24,7 @@ export function SettingsDropdown() {
       <DropdownMenuContent align="end">
         <DropdownMenuLabel>Settings</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuCheckboxItem
-          checked={showHiddenNotes}
-          onCheckedChange={toggleShowHiddenNotes}
-        >
+        <DropdownMenuCheckboxItem checked={showHiddenNotes} onCheckedChange={toggleShowHiddenNotes}>
           <EyeOff className="mr-2 h-4 w-4" />
           Show hidden notes
         </DropdownMenuCheckboxItem>

--- a/frontend/src/components/ui/text-input.tsx
+++ b/frontend/src/components/ui/text-input.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback, useEffect, forwardRef } from 'react';
-import { Paperclip, Smile, Send } from 'lucide-react';
+import { Paperclip, Smile, Send, EyeOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
@@ -13,6 +13,8 @@ interface TextInputProps {
   autoFocus?: boolean;
   className?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  isHidden?: boolean;
+  onHiddenChange?: (value: boolean) => void;
 }
 
 export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
@@ -26,6 +28,8 @@ export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
       autoFocus = false,
       className,
       onKeyDown,
+      isHidden = false,
+      onHiddenChange,
     },
     ref
   ) => {
@@ -88,6 +92,18 @@ export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
             <Button size="icon" variant="ghost" className="h-7 w-7" type="button">
               <Smile className="h-4 w-4" />
             </Button>
+            {onHiddenChange && (
+              <Button
+                size="icon"
+                variant="ghost"
+                className={cn('h-7 w-7', isHidden && 'text-primary bg-primary/10')}
+                type="button"
+                onClick={() => onHiddenChange(!isHidden)}
+                title={isHidden ? 'Hidden note (click to make visible)' : 'Make this note hidden'}
+              >
+                <EyeOff className="h-4 w-4" />
+              </Button>
+            )}
           </div>
         </div>
         <Button

--- a/frontend/src/hooks/useApiClient.ts
+++ b/frontend/src/hooks/useApiClient.ts
@@ -100,6 +100,12 @@ export const useApiClient = () => {
         body: body ? JSON.stringify(body) : undefined,
       }),
 
+    patch: <T>(endpoint: string, body?: unknown) =>
+      apiFetch<T>(endpoint, {
+        method: 'PATCH',
+        body: body ? JSON.stringify(body) : undefined,
+      }),
+
     delete: <T>(endpoint: string) => apiFetch<T>(endpoint, { method: 'DELETE' }),
   };
 };

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -68,11 +68,12 @@ export const NotesPage: React.FC = () => {
   };
 
   // NOTE: Create new note or reply
-  const handleCreateNote = async (content: string) => {
+  const handleCreateNote = async (content: string, isHidden?: boolean) => {
     try {
       const newNote = await createNote.mutateAsync({
         content,
         parentId: replyingToNoteId || undefined,
+        isHidden,
       });
 
       // NOTE: Select newly created note

--- a/frontend/src/store/settings.store.tsx
+++ b/frontend/src/store/settings.store.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+  useEffect,
+} from 'react';
 
 const STORAGE_KEY = 'thread-settings';
 

--- a/frontend/src/store/settings.store.tsx
+++ b/frontend/src/store/settings.store.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
+
+const STORAGE_KEY = 'thread-settings';
+
+interface SettingsState {
+  showHiddenNotes: boolean;
+}
+
+interface SettingsContextValue extends SettingsState {
+  toggleShowHiddenNotes: () => void;
+  setShowHiddenNotes: (value: boolean) => void;
+}
+
+const defaultState: SettingsState = {
+  showHiddenNotes: false,
+};
+
+const loadFromStorage = (): SettingsState => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return { ...defaultState, ...JSON.parse(stored) };
+    }
+  } catch (e) {
+    console.error('Failed to load settings from localStorage:', e);
+  }
+  return defaultState;
+};
+
+const saveToStorage = (state: SettingsState) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.error('Failed to save settings to localStorage:', e);
+  }
+};
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<SettingsState>(() => loadFromStorage());
+
+  // NOTE: Persist to localStorage whenever state changes
+  useEffect(() => {
+    saveToStorage(state);
+  }, [state]);
+
+  const toggleShowHiddenNotes = useCallback(() => {
+    setState((prev) => ({ ...prev, showHiddenNotes: !prev.showHiddenNotes }));
+  }, []);
+
+  const setShowHiddenNotes = useCallback((value: boolean) => {
+    setState((prev) => ({ ...prev, showHiddenNotes: value }));
+  }, []);
+
+  const value: SettingsContextValue = {
+    ...state,
+    toggleShowHiddenNotes,
+    setShowHiddenNotes,
+  };
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+};
+
+export const useSettings = (): SettingsContextValue => {
+  const context = useContext(SettingsContext);
+
+  if (!context) {
+    throw new Error('useSettings must be used within SettingsProvider');
+  }
+
+  return context;
+};


### PR DESCRIPTION
- Add settings store with localStorage persistence for showHiddenNotes preference
- Create SettingsDropdown component in header for toggling hidden notes visibility
- Add hidden checkbox in note dropdown menu (visible only when showHiddenNotes is enabled)
- Update NoteList to display EyeOff icon for hidden notes
- Add PATCH /api/notes/:id/hidden endpoint to toggle hidden status
- Update frontend note service with useUpdateNoteHidden hook
- Pass includeHidden parameter to useInfiniteNotes based on settings