### PR TITLE
fix: add frontend build step before production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,6 +32,10 @@ jobs:
           echo "VITE_BACKEND_API_ENDPOINT=${{ vars.VITE_BACKEND_API_ENDPOINT_PRODUCTION }}" > .env.production
           echo "VITE_CLERK_PUBLISHABLE_KEY=${{ vars.VITE_CLERK_PUBLISHABLE_KEY_PRODUCTION }}" >> .env.production
 
+      - name: Build Frontend for Production
+        working-directory: frontend
+        run: bun run build:production
+
       - name: Deploy Frontend to Production
         working-directory: frontend
         run: bun run deploy:production


### PR DESCRIPTION
## Summary
- Adds missing `bun run build:production` step before deploying frontend to production
- Ensures fresh build artifacts are deployed instead of potentially stale or missing ones

## Test plan
- [ ] Verify workflow runs successfully on merge
- [ ] Confirm production deployment includes latest changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)