### PR TITLE
refactor: replace dropdown menus with inline action bars

### DIFF
--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -1,31 +1,15 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFocus } from '@/store/focus.context';
-import {
-  X,
-  MoreVertical,
-  Trash2,
-  Link2,
-  Edit,
-  Pin,
-  ArrowLeft,
-  MessageSquare,
-  Bookmark,
-} from 'lucide-react';
+import { X, Trash2, Link2, Edit, Pin, ArrowLeft, MessageSquare, Bookmark } from 'lucide-react';
 import { Note } from '../../../shared/types';
-import { cn, getRelativeTime } from '@/lib/utils';
+import { getRelativeTime } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import NoteEditor from './NoteEditor';
 import { TextInput } from '@/components/ui/text-input';
-import { useIsBookmarked, useToggleBookmark } from '@/services/bookmark.service';
+
 import { BookmarkButton } from '@/components/bookmarks/BookmarkButton';
 
 interface ThreadViewProps {
@@ -54,9 +38,6 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
   const isMobile = !useMediaQuery('(min-width: 1024px)');
   const replyInputRef = useRef<HTMLTextAreaElement>(null);
   const { registerInput, unregisterInput } = useFocus();
-  const { data: isRootBookmarked } = useIsBookmarked(rootNote.id);
-  const toggleBookmark = useToggleBookmark();
-
   // NOTE: Register reply input with FocusContext
   useEffect(() => {
     registerInput('thread-reply', replyInputRef);
@@ -178,48 +159,37 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
           {/* Original Message */}
           <div className="border-b border-border p-4">
             <div className="group relative space-y-2" data-testid="thread-node">
-              <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button size="icon" variant="ghost" className="h-7 w-7">
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem>
-                      <Pin className="mr-2 h-4 w-4" />
-                      Pin note
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => toggleBookmark.mutate(rootNote.id)}>
-                      <Bookmark
-                        className={cn(
-                          'mr-2 h-4 w-4',
-                          isRootBookmarked && 'fill-yellow-500 text-yellow-500'
-                        )}
-                      />
-                      {isRootBookmarked ? 'Remove bookmark' : 'Bookmark'}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => copyLink(rootNote.id)}>
-                      <Link2 className="mr-2 h-4 w-4" />
-                      Copy link
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setIsEditing(rootNote.id)}
-                      data-testid="thread-action-edit"
-                    >
-                      <Edit className="mr-2 h-4 w-4" />
-                      Edit note
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => handleDelete(rootNote.id)}
-                      className="text-destructive"
-                      data-testid="thread-action-delete"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete note
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+              <div className="absolute -top-1 right-0 flex items-center gap-0.5 rounded-md border border-border bg-background px-0.5 py-0.5 shadow-sm opacity-0 transition-opacity group-hover:opacity-100">
+                <BookmarkButton noteId={rootNote.id} size="sm" />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={() => copyLink(rootNote.id)}
+                  aria-label="Copy link"
+                >
+                  <Link2 className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7"
+                  onClick={() => setIsEditing(rootNote.id)}
+                  aria-label="Edit note"
+                  data-testid="thread-action-edit"
+                >
+                  <Edit className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-7 w-7 text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(rootNote.id)}
+                  aria-label="Delete note"
+                  data-testid="thread-action-delete"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
               </div>
 
               {/* Tags */}
@@ -338,39 +308,37 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
             ) : (
               replies.map((note) => (
                 <div key={note.id} className="group relative space-y-2" data-testid="thread-node">
-                  <div className="absolute top-0 right-0 opacity-0 transition-opacity group-hover:opacity-100">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button size="icon" variant="ghost" className="h-7 w-7">
-                          <MoreVertical className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => toggleBookmark.mutate(note.id)}>
-                          <Bookmark className="mr-2 h-4 w-4" />
-                          Bookmark
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => copyLink(note.id)}>
-                          <Link2 className="mr-2 h-4 w-4" />
-                          Copy link
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => setIsEditing(note.id)}
-                          data-testid="thread-action-edit"
-                        >
-                          <Edit className="mr-2 h-4 w-4" />
-                          Edit note
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => handleDelete(note.id)}
-                          className="text-destructive"
-                          data-testid="thread-action-delete"
-                        >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          Delete note
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                  <div className="absolute -top-1 right-0 flex items-center gap-0.5 rounded-md border border-border bg-background px-0.5 py-0.5 shadow-sm opacity-0 transition-opacity group-hover:opacity-100">
+                    <BookmarkButton noteId={note.id} size="sm" />
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7"
+                      onClick={() => copyLink(note.id)}
+                      aria-label="Copy link"
+                    >
+                      <Link2 className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7"
+                      onClick={() => setIsEditing(note.id)}
+                      aria-label="Edit note"
+                      data-testid="thread-action-edit"
+                    >
+                      <Edit className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7 text-destructive hover:text-destructive"
+                      onClick={() => handleDelete(note.id)}
+                      aria-label="Delete note"
+                      data-testid="thread-action-delete"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
                   </div>
 
                   {/* Tags */}

--- a/frontend/src/components/notes/NoteActionMenu.tsx
+++ b/frontend/src/components/notes/NoteActionMenu.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
-import { MoreVertical, Trash2, Bookmark, Link2, Edit, Pin, EyeOff } from 'lucide-react';
+import { Link2, EyeOff, Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuCheckboxItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { BookmarkButton } from '@/components/bookmarks/BookmarkButton';
 
 interface NoteActionMenuProps {
   noteId: string;
@@ -34,47 +27,29 @@ export const NoteActionMenu: React.FC<NoteActionMenuProps> = ({
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button size="icon" variant="ghost" className="h-7 w-7">
-          <MoreVertical className="h-4 w-4" />
+    <div className="flex items-center gap-0.5 rounded-md border border-border bg-background px-0.5 py-0.5 shadow-sm">
+      <BookmarkButton noteId={noteId} size="sm" />
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7"
+        onClick={handleCopyLink}
+        aria-label="Copy link"
+      >
+        <Link2 className="h-3.5 w-3.5" />
+      </Button>
+      {showHiddenToggle && onToggleHidden && (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7"
+          onClick={() => onToggleHidden(noteId, !isHidden)}
+          aria-label={isHidden ? 'Show note' : 'Hide note'}
+        >
+          {isHidden ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {showHiddenToggle && onToggleHidden && (
-          <>
-            <DropdownMenuCheckboxItem
-              checked={isHidden}
-              onCheckedChange={(checked) => onToggleHidden(noteId, checked)}
-            >
-              <EyeOff className="mr-2 h-4 w-4" />
-              Hidden
-            </DropdownMenuCheckboxItem>
-            <DropdownMenuSeparator />
-          </>
-        )}
-        <DropdownMenuItem>
-          <Pin className="mr-2 h-4 w-4" />
-          Pin note
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Bookmark className="mr-2 h-4 w-4" />
-          Bookmark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleCopyLink}>
-          <Link2 className="mr-2 h-4 w-4" />
-          Copy link
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Edit className="mr-2 h-4 w-4" />
-          Edit note
-        </DropdownMenuItem>
-        <DropdownMenuItem className="text-destructive">
-          <Trash2 className="mr-2 h-4 w-4" />
-          Delete note
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/notes/NoteItem.tsx
+++ b/frontend/src/components/notes/NoteItem.tsx
@@ -37,8 +37,8 @@ export const NoteItem: React.FC<NoteItemProps> = ({
       )}
       data-testid="note-item"
     >
-      {/* Action Menu */}
-      <div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
+      {/* Inline Action Bar */}
+      <div className="absolute -top-1 right-2 opacity-0 transition-opacity group-hover:opacity-100">
         <NoteActionMenu
           noteId={note.id}
           isHidden={note.isHidden}

--- a/frontend/tests/e2e/03-view-thread.spec.ts
+++ b/frontend/tests/e2e/03-view-thread.spec.ts
@@ -118,7 +118,7 @@ test.describe('View Thread', () => {
     await expect(page.locator('text=2 replies')).toBeVisible();
   });
 
-  test('should display action menu in thread', async ({ page }) => {
+  test('should display action buttons on hover in thread', async ({ page }) => {
     await page.goto('/');
 
     // NOTE: Create and select note with unique content
@@ -131,12 +131,11 @@ test.describe('View Thread', () => {
     // NOTE: Verify reply input is visible
     await expect(page.locator('[data-testid="thread-reply-input"]')).toBeVisible();
 
-    // NOTE: Open dropdown menu by hovering and clicking the three-dot button
+    // NOTE: Hover over thread node to reveal inline action buttons
     const threadNode = page.locator('[data-testid="thread-node"]').first();
     await threadNode.hover();
-    await threadNode.locator('button:has(svg)').click();
 
-    // NOTE: Verify edit and delete actions are in the menu
+    // NOTE: Verify edit and delete action buttons are visible directly (no dropdown)
     await expect(page.locator('[data-testid="thread-action-edit"]')).toBeVisible({ timeout: 5000 });
     await expect(page.locator('[data-testid="thread-action-delete"]')).toBeVisible({
       timeout: 5000,

--- a/frontend/tests/e2e/06-delete-note.spec.ts
+++ b/frontend/tests/e2e/06-delete-note.spec.ts
@@ -56,19 +56,14 @@ test.describe('Delete Note', () => {
       await dialog.accept();
     });
 
-    // NOTE: Hover over thread node to reveal menu button
+    // NOTE: Hover over thread node to reveal inline action buttons
     const threadNode = page.locator('[data-testid="thread-node"]').first();
     await threadNode.hover();
 
-    // NOTE: Open dropdown menu
-    const menuButton = threadNode.locator('button').first();
-    await menuButton.waitFor({ state: 'visible', timeout: 5000 });
-    await menuButton.click();
-
-    // NOTE: Click delete from dropdown
+    // NOTE: Click delete button directly (inline action bar)
     const deleteButton = page.locator(selectors.threadView.deleteButton);
-    await deleteButton.waitFor({ state: 'visible', timeout: 10000 });
-    await deleteButton.click({ force: true });
+    await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+    await deleteButton.click();
 
     // NOTE: Wait a moment for dialog
     await page.waitForTimeout(500);
@@ -139,19 +134,14 @@ test.describe('Delete Note', () => {
       await dialog.dismiss();
     });
 
-    // NOTE: Hover over thread node to reveal menu button
+    // NOTE: Hover over thread node to reveal inline action buttons
     const threadNode = page.locator('[data-testid="thread-node"]').first();
     await threadNode.hover();
 
-    // NOTE: Open dropdown menu
-    const menuButton = threadNode.locator('button').first();
-    await menuButton.waitFor({ state: 'visible', timeout: 5000 });
-    await menuButton.click();
-
-    // NOTE: Click delete from dropdown
+    // NOTE: Click delete button directly (inline action bar)
     const deleteButton = page.locator(selectors.threadView.deleteButton);
-    await deleteButton.waitFor({ state: 'visible', timeout: 10000 });
-    await deleteButton.click({ force: true });
+    await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+    await deleteButton.click();
 
     // NOTE: Wait a moment
     await page.waitForTimeout(500);

--- a/frontend/tests/e2e/08-bookmarks.spec.ts
+++ b/frontend/tests/e2e/08-bookmarks.spec.ts
@@ -21,19 +21,21 @@ test.describe('Bookmarks', () => {
     // NOTE: Select the note to open ThreadView
     await selectNoteByContent(page, 'Bookmarked note for E2E test');
 
-    // NOTE: Hover over thread node to reveal action menu
+    // NOTE: Hover over thread node to reveal inline action buttons
     const threadNode = page.locator('[data-testid="thread-node"]').first();
     await threadNode.hover();
 
-    // NOTE: Click the dropdown trigger (three dots menu)
-    const menuButton = threadNode.locator('button').first();
-    await menuButton.waitFor({ state: 'visible', timeout: 5000 });
-    await menuButton.click();
+    // NOTE: Click bookmark button directly in the inline action bar
+    const bookmarkButton = threadNode.getByRole('button', { name: /bookmark/i });
+    await bookmarkButton.waitFor({ state: 'visible', timeout: 5000 });
 
-    // NOTE: Click "Bookmark" in the dropdown menu
-    const bookmarkMenuItem = page.getByRole('menuitem', { name: 'Bookmark' });
-    await bookmarkMenuItem.waitFor({ state: 'visible', timeout: 5000 });
-    await bookmarkMenuItem.click();
+    const bookmarkResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/bookmarks/') && response.request().method() === 'POST',
+      { timeout: 10000 }
+    );
+    await bookmarkButton.click();
+    await bookmarkResponse;
 
     // NOTE: Navigate to bookmarks page and verify
     await page.getByRole('button', { name: 'Bookmarks' }).click();

--- a/frontend/tests/e2e/setup/test-helpers.ts
+++ b/frontend/tests/e2e/setup/test-helpers.ts
@@ -180,21 +180,14 @@ export async function deleteNote(page: Page) {
     { timeout: 15000 }
   );
 
-  // NOTE: Hover over thread node to show menu button
+  // NOTE: Hover over thread node to show inline action buttons
   const threadNode = page.locator('[data-testid="thread-node"]').first();
   await threadNode.hover();
 
-  // NOTE: Find and click the dropdown menu button
-  const menuButton = threadNode.locator('button').first();
-  await menuButton.waitFor({ state: 'visible', timeout: 5000 });
-  await menuButton.click();
-
-  // NOTE: Wait for dropdown menu to be visible (portal rendered)
+  // NOTE: Click delete button directly (inline action bar, no dropdown)
   const deleteButton = page.locator('[data-testid="thread-action-delete"]');
-  await deleteButton.waitFor({ state: 'visible', timeout: 10000 });
-
-  // NOTE: Click delete menu item (force click as it might be in a portal/dropdown)
-  await deleteButton.click({ force: true });
+  await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+  await deleteButton.click();
 
   // NOTE: Wait for deletion to complete
   await responsePromise;


### PR DESCRIPTION
## Summary

- Replace three-dot DropdownMenu with inline action buttons that appear on hover in both ThreadView and NoteList
- Reduces user interaction from 3 steps (hover → click menu → click item) to 1 step (hover → click button)
- ThreadView: Bookmark, Copy link, Edit, Delete shown as inline icon buttons
- NoteList: Bookmark, Copy link, Hide toggle shown as inline icon buttons
- Update E2E tests to match new direct-click interaction pattern

## Test plan

- [ ] Hover over a note in NoteList → verify inline action bar appears (Bookmark, Link, Hide)
- [ ] Hover over a message in ThreadView → verify inline action bar appears (Bookmark, Link, Edit, Delete)
- [ ] Click each inline button and verify functionality
- [ ] Run `bun run test:e2e` to validate updated E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)