### PR TITLE
fix: invalidate tasks cache on note create/update/delete

### DIFF
--- a/frontend/src/services/note.service.ts
+++ b/frontend/src/services/note.service.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 import { useApiClient } from '../hooks/useApiClient';
 import type { Note, SearchResponse } from '../../../shared/types';
+import { taskKeys } from './task.service';
 
 // NOTE: API response types
 interface NotesListResponse {
@@ -165,6 +166,9 @@ export const useCreateNote = () => {
       if (newNote.parentId) {
         queryClient.invalidateQueries({ queryKey: noteKeys.detail(newNote.parentId) });
       }
+
+      // NOTE: Invalidate tasks cache since note content may contain checkbox tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };
@@ -210,6 +214,9 @@ export const useUpdateNote = () => {
       // NOTE: Invalidate related queries
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(updatedNote.id) });
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // NOTE: Invalidate tasks cache since edited content may add/remove checkbox tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };
@@ -248,6 +255,9 @@ export const useDeleteNote = () => {
 
       // NOTE: Remove deleted note from cache
       queryClient.removeQueries({ queryKey: noteKeys.detail(deletedId) });
+
+      // NOTE: Invalidate tasks cache since deleted note may have had tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };


### PR DESCRIPTION
## Summary
- ノート作成/更新/削除時に React Query の tasks キャッシュが invalidate されていなかったバグを修正
- `useCreateNote`, `useUpdateNote`, `useDeleteNote` の `onSuccess` に `taskKeys.lists()` の invalidation を追加
- チェックボックス構文(`- [ ] task`)を含むノートを作成後、タスクページに即座に反映されるように

## Root Cause
`useTasks` の `staleTime` が1分に設定されているため、タスクページを先に訪問していた場合、ノート操作後も古いキャッシュが使い回されていた。

## Test plan
- [ ] ノートに `- [ ] テスト` を入力して作成 → /tasks に遷移 → 即座にタスクが表示される
- [ ] ノートのチェックボックスを編集 → /tasks の表示が更新される
- [ ] チェックボックス付きノートを削除 → /tasks からタスクが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)