### PR TITLE
feat: add NoteContent component, daily notes auto-save, and tasks cache invalidation

### DIFF
--- a/backend/src/services/daily-note/daily-note.service.ts
+++ b/backend/src/services/daily-note/daily-note.service.ts
@@ -95,17 +95,17 @@ export const createDailyNoteService = ({ db }: { db: Database }): DailyNoteServi
 
     getCalendar: (authorId, year, month) =>
       dailyNoteRepo
-        .findByAuthorAndDateRange(
+        .findEditedByAuthorAndDateRange(
           authorId,
           `${formatDate(year, month)}-01`,
           `${formatDate(year, month)}-31`
         )
-        .map((dailyNotes) => {
-          const datesWithNotes = new Set(dailyNotes.map((dn) => dn.date));
+        .map((editedNotes) => {
+          const editedDates = new Set(editedNotes.map((dn) => dn.date));
           const daysInMonth = new Date(year, month, 0).getDate();
           return Array.from({ length: daysInMonth }, (_, i) => {
             const dateStr = formatDate(year, month, i + 1);
-            return { date: dateStr, hasNote: datesWithNotes.has(dateStr) } as CalendarEntry;
+            return { date: dateStr, hasNote: editedDates.has(dateStr) } as CalendarEntry;
           });
         }),
 

--- a/frontend/src/components/NoteContent.tsx
+++ b/frontend/src/components/NoteContent.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface NoteContentProps {
+  content: string;
+  onMentionClick?: (noteId: string) => void;
+  truncate?: number;
+  className?: string;
+  'data-testid'?: string;
+}
+
+const TASK_PREFIX = '- [x] ';
+const TASK_PREFIX_LENGTH = TASK_PREFIX.length;
+
+const renderMentions = (
+  text: string,
+  onMentionClick?: (noteId: string) => void,
+  navigate?: ReturnType<typeof useNavigate>
+): React.ReactNode[] => {
+  const parts = text.split(/(@\w{6})/g);
+  return parts.map((part, index) => {
+    if (part.match(/^@\w{6}$/)) {
+      const noteId = part.substring(1);
+      return (
+        <a
+          key={index}
+          href={`#${noteId}`}
+          className="text-primary hover:underline"
+          aria-label={`Go to note ${noteId}`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (onMentionClick) {
+              onMentionClick(noteId);
+            } else if (navigate) {
+              navigate(`/notes/${noteId}`);
+            }
+          }}
+        >
+          {part}
+        </a>
+      );
+    }
+    if (!part) return null;
+    return <span key={index}>{part}</span>;
+  });
+};
+
+const renderLine = (
+  line: string,
+  lineIndex: number,
+  onMentionClick?: (noteId: string) => void,
+  navigate?: ReturnType<typeof useNavigate>
+): React.ReactNode => {
+  if (line.match(/^### /)) {
+    return (
+      <span key={lineIndex} className="font-semibold">
+        {renderMentions(line, onMentionClick, navigate)}
+      </span>
+    );
+  }
+  if (line.match(/^## /)) {
+    return (
+      <span key={lineIndex} className="font-bold">
+        {renderMentions(line, onMentionClick, navigate)}
+      </span>
+    );
+  }
+  if (line.match(/^# /)) {
+    return (
+      <span key={lineIndex} className="mt-1 font-black">
+        {renderMentions(line, onMentionClick, navigate)}
+      </span>
+    );
+  }
+
+  // NOTE: Task patterns must be checked before plain list to avoid `- [ ]` matching as a list item
+  if (line.match(/^- \[x\] /)) {
+    const taskText = line.slice(TASK_PREFIX_LENGTH);
+    return (
+      <span key={lineIndex} className="text-muted-foreground opacity-60 line-through">
+        <span className="mr-1 rounded bg-muted px-1 font-mono">- [x]</span>
+        {renderMentions(taskText, onMentionClick, navigate)}
+      </span>
+    );
+  }
+
+  if (line.match(/^- \[ \] /)) {
+    const taskText = line.slice(TASK_PREFIX_LENGTH);
+    return (
+      <span key={lineIndex}>
+        <span className="mr-1 rounded bg-muted px-1 font-mono text-muted-foreground">- [ ]</span>
+        {renderMentions(taskText, onMentionClick, navigate)}
+      </span>
+    );
+  }
+
+  if (line.match(/^- /)) {
+    const listText = line.slice(2);
+    return (
+      <span key={lineIndex} className="inline-flex items-baseline pl-1">
+        <span className="mr-1.5 text-muted-foreground" aria-hidden="true">
+          ·
+        </span>
+        {renderMentions(listText, onMentionClick, navigate)}
+      </span>
+    );
+  }
+
+  return <span key={lineIndex}>{renderMentions(line, onMentionClick, navigate)}</span>;
+};
+
+export const NoteContent: React.FC<NoteContentProps> = ({
+  content,
+  onMentionClick,
+  truncate,
+  className,
+  'data-testid': dataTestId,
+}) => {
+  const navigate = useNavigate();
+
+  const displayContent =
+    truncate && content.length > truncate ? content.substring(0, truncate) + '...' : content;
+
+  const lines = displayContent.split('\n');
+
+  return (
+    <div
+      className={className ?? 'text-foreground text-sm leading-relaxed'}
+      data-testid={dataTestId}
+    >
+      {lines.map((line, index) => (
+        <React.Fragment key={index}>
+          {renderLine(line, index, onMentionClick, navigate)}
+          {index < lines.length - 1 && <br />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/ThreadView.tsx
+++ b/frontend/src/components/ThreadView.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import NoteEditor from './NoteEditor';
+import { NoteContent } from '@/components/NoteContent';
 import { TextInput } from '@/components/ui/text-input';
 
 import { BookmarkButton } from '@/components/bookmarks/BookmarkButton';
@@ -92,30 +93,6 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
     if (window.confirm('Delete this note? This cannot be undone.')) {
       await onDelete(noteId);
     }
-  };
-
-  const renderContent = (content: string) => {
-    // NOTE: Parse mentions and make them clickable
-    const parts = content.split(/(@\w{6})/g);
-    return parts.map((part, index) => {
-      if (part.match(/^@\w{6}$/)) {
-        const noteId = part.substring(1);
-        return (
-          <a
-            key={index}
-            href={`#${noteId}`}
-            className="text-primary hover:underline"
-            onClick={(e) => {
-              e.preventDefault();
-              navigate(`/notes/${noteId}`);
-            }}
-          >
-            {part}
-          </a>
-        );
-      }
-      return <span key={index}>{part}</span>;
-    });
   };
 
   // NOTE: Get replies (all notes except root)
@@ -234,12 +211,11 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
                 />
               ) : (
                 <>
-                  <p
-                    className="text-foreground text-sm leading-relaxed"
+                  <NoteContent
+                    content={rootNote.content}
+                    onMentionClick={(noteId) => navigate(`/notes/${noteId}`)}
                     data-testid="thread-node-content"
-                  >
-                    {renderContent(rootNote.content)}
-                  </p>
+                  />
 
                   {/* Image Previews */}
                   {rootNote.images && rootNote.images.length > 0 && (
@@ -383,12 +359,11 @@ export const ThreadView: React.FC<ThreadViewProps> = ({
                     />
                   ) : (
                     <>
-                      <p
-                        className="text-foreground text-sm leading-relaxed"
+                      <NoteContent
+                        content={note.content}
+                        onMentionClick={(noteId) => navigate(`/notes/${noteId}`)}
                         data-testid="thread-node-content"
-                      >
-                        {renderContent(note.content)}
-                      </p>
+                      />
 
                       {/* Image Previews */}
                       {note.images && note.images.length > 0 && (

--- a/frontend/src/components/notes/NoteItem.tsx
+++ b/frontend/src/components/notes/NoteItem.tsx
@@ -4,6 +4,7 @@ import { Note } from '../../../../shared/types';
 import { cn, getRelativeTime } from '@/lib/utils';
 import { NoteActionMenu } from './NoteActionMenu';
 import { ImagePreview } from './ImagePreview';
+import { NoteContent } from '@/components/NoteContent';
 
 interface NoteItemProps {
   note: Note;
@@ -14,11 +15,6 @@ interface NoteItemProps {
   onToggleImageExpansion: (noteId: string) => void;
   onToggleHidden?: (noteId: string, isHidden: boolean) => void;
 }
-
-const truncateContent = (content: string, maxLength: number = 100): string => {
-  if (content.length <= maxLength) return content;
-  return content.substring(0, maxLength) + '...';
-};
 
 export const NoteItem: React.FC<NoteItemProps> = ({
   note,
@@ -96,9 +92,7 @@ export const NoteItem: React.FC<NoteItemProps> = ({
 
           {/* Content */}
           <div className="space-y-2">
-            <p className="text-foreground text-sm leading-relaxed" data-testid="note-item-content">
-              {truncateContent(note.content)}
-            </p>
+            <NoteContent content={note.content} truncate={100} data-testid="note-item-content" />
 
             {/* Image Previews */}
             {note.images && note.images.length > 0 && (

--- a/frontend/src/services/daily-note.service.ts
+++ b/frontend/src/services/daily-note.service.ts
@@ -18,7 +18,7 @@ interface DailyNoteResponse {
 
 interface CalendarEntry {
   date: string;
-  noteId: string;
+  hasNote: boolean;
 }
 
 interface CalendarResponse {

--- a/frontend/src/services/note.service.ts
+++ b/frontend/src/services/note.service.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 import { useApiClient } from '../hooks/useApiClient';
 import type { Note, SearchResponse } from '../../../shared/types';
+import { taskKeys } from './task.service';
 
 // NOTE: API response types
 interface NotesListResponse {
@@ -165,6 +166,9 @@ export const useCreateNote = () => {
       if (newNote.parentId) {
         queryClient.invalidateQueries({ queryKey: noteKeys.detail(newNote.parentId) });
       }
+
+      // NOTE: Invalidate tasks cache since note content may contain checkbox tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };
@@ -210,6 +214,9 @@ export const useUpdateNote = () => {
       // NOTE: Invalidate related queries
       queryClient.invalidateQueries({ queryKey: noteKeys.detail(updatedNote.id) });
       queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+
+      // NOTE: Invalidate tasks cache since edited content may add/remove checkbox tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };
@@ -248,6 +255,9 @@ export const useDeleteNote = () => {
 
       // NOTE: Remove deleted note from cache
       queryClient.removeQueries({ queryKey: noteKeys.detail(deletedId) });
+
+      // NOTE: Invalidate tasks cache since deleted note may have had tasks
+      queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     },
   });
 };


### PR DESCRIPTION
## Summary

This PR contains 3 changes:

### 1. NoteContent component with custom markdown styling
- Created `NoteContent` component that renders note content with custom markdown-like styling while preserving original markdown characters
- Headers (`#`, `##`, `###`): displayed with original `#`, styled with font-weight (black/bold/semibold)
- Tasks (`- [ ]`, `- [x]`): checkbox prefix styled with mono font + muted bg; completed tasks get line-through; active tasks keep white text
- Lists (`- item`): rendered with `·` bullet marker and slight indent
- Line breaks (`\n`) correctly reflected
- Mentions (`@xxxxxx`) remain clickable with proper event propagation (`stopPropagation`)
- Replaced inline `renderContent` in ThreadView and `truncateContent` in NoteItem with shared `NoteContent`

**Files:** `NoteContent.tsx` (new), `ThreadView.tsx`, `NoteItem.tsx`

### 2. Daily notes always-editable with debounced auto-save
- Removed edit/save/cancel button flow from DailyNotesPage
- Textarea is now always editable with debounced auto-save (content saves automatically after typing stops)
- Added saving/saved status indicators in the header
- Flushes pending save before date navigation
- Calendar now only highlights dates where the note has been edited (not just created)
- Backend: added `findEditedByAuthorAndDateRange` repository method filtering by `updatedAt > createdAt`
- Frontend: `CalendarEntry.noteId` changed to `CalendarEntry.hasNote` (boolean)

**Files:** `DailyNotesPage.tsx`, `daily-note.service.ts` (frontend), `daily-note.repository.ts`, `daily-note.service.ts` (backend)

### 3. Invalidate tasks cache on note mutations
- Tasks cache is now invalidated when notes are created, updated, or deleted
- Ensures task list stays in sync when checkbox tasks (`- [ ]`, `- [x]`) are added/removed/changed in notes

**Files:** `note.service.ts` (frontend)

## Test plan
- [ ] Create a note with headers, tasks, lists, and mentions — verify styling
- [ ] Verify NoteList preview truncation works with styled content
- [ ] Open daily notes, type content — verify auto-save with "Saving..."/"Saved" indicators
- [ ] Navigate between dates — verify pending save is flushed
- [ ] Calendar highlights only edited dates
- [ ] Create/edit/delete a note with checkbox tasks — verify tasks page updates
- [ ] Run `bun run lint && bun run typecheck && bun run format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)