### PR TITLE
feat: add Command Palette (Cmd+K)

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Bookmark, CheckSquare, Calendar, Hash, StickyNote, Search } from 'lucide-react';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useChannels } from '@/services/channel.service';
+import { cn } from '@/lib/utils';
+
+interface CommandItem {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  action: () => void;
+  group: string;
+}
+
+interface CommandOptionProps {
+  cmd: CommandItem;
+  isSelected: boolean;
+  onExecute: (cmd: CommandItem) => void;
+  onSelect: (index: number) => void;
+  globalIndex: number;
+}
+
+const CommandOption = React.memo<CommandOptionProps>(
+  ({ cmd, isSelected, onExecute, onSelect, globalIndex }) => {
+    const handleClick = useCallback(() => onExecute(cmd), [onExecute, cmd]);
+    const handleMouseEnter = useCallback(() => onSelect(globalIndex), [onSelect, globalIndex]);
+
+    return (
+      <button
+        role="option"
+        aria-selected={isSelected}
+        data-selected={isSelected}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+          isSelected ? 'bg-accent text-accent-foreground' : 'text-foreground'
+        )}
+      >
+        {cmd.icon}
+        <span>{cmd.label}</span>
+      </button>
+    );
+  }
+);
+
+CommandOption.displayName = 'CommandOption';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onToggleScratchPad: () => void;
+}
+
+export const CommandPalette: React.FC<CommandPaletteProps> = ({
+  open,
+  onOpenChange,
+  onToggleScratchPad,
+}) => {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const prevQueryRef = useRef(query);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+  const { data: channels } = useChannels();
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const items: CommandItem[] = [
+      {
+        id: 'nav-notes',
+        label: 'All Notes',
+        icon: <StickyNote className="h-4 w-4" />,
+        action: () => navigate('/'),
+        group: 'Navigation',
+      },
+      {
+        id: 'nav-bookmarks',
+        label: 'Bookmarks',
+        icon: <Bookmark className="h-4 w-4" />,
+        action: () => navigate('/bookmarks'),
+        group: 'Navigation',
+      },
+      {
+        id: 'nav-tasks',
+        label: 'Tasks',
+        icon: <CheckSquare className="h-4 w-4" />,
+        action: () => navigate('/tasks'),
+        group: 'Navigation',
+      },
+      {
+        id: 'nav-daily',
+        label: 'Daily Notes',
+        icon: <Calendar className="h-4 w-4" />,
+        action: () => {
+          const today = new Date().toISOString().split('T')[0];
+          navigate(`/daily/${today}`);
+        },
+        group: 'Navigation',
+      },
+    ];
+
+    if (channels) {
+      for (const channel of channels) {
+        items.push({
+          id: `channel-${channel.id}`,
+          label: channel.name,
+          icon: <Hash className="h-4 w-4" style={{ color: channel.color }} />,
+          action: () => navigate(`/channels/${channel.id}`),
+          group: 'Channels',
+        });
+      }
+    }
+
+    items.push({
+      id: 'action-scratchpad',
+      label: 'Toggle Scratch Pad',
+      icon: <StickyNote className="h-4 w-4" />,
+      action: onToggleScratchPad,
+      group: 'Actions',
+    });
+
+    return items;
+  }, [navigate, channels, onToggleScratchPad]);
+
+  const filtered = useMemo(() => {
+    if (!query) return commands;
+    const lower = query.toLowerCase();
+    return commands.filter((cmd) => cmd.label.toLowerCase().includes(lower));
+  }, [commands, query]);
+
+  // Reset selectedIndex when query changes (derived reset via ref comparison)
+  if (prevQueryRef.current !== query) {
+    prevQueryRef.current = query;
+    if (selectedIndex !== 0) {
+      setSelectedIndex(0);
+    }
+  }
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setSelectedIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const executeCommand = useCallback(
+    (cmd: CommandItem) => {
+      onOpenChange(false);
+      cmd.action();
+    },
+    [onOpenChange]
+  );
+
+  const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : 0));
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : filtered.length - 1));
+          break;
+        }
+        case 'Enter': {
+          e.preventDefault();
+          const cmd = filtered[selectedIndex];
+          if (cmd) executeCommand(cmd);
+          break;
+        }
+      }
+    },
+    [filtered, selectedIndex, executeCommand]
+  );
+
+  useEffect(() => {
+    const selectedEl = listRef.current?.querySelector('[data-selected="true"]');
+    selectedEl?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  const groupedFiltered = useMemo(() => {
+    const groups: { name: string; items: { cmd: CommandItem; globalIndex: number }[] }[] = [];
+    const groupMap = new Map<string, { cmd: CommandItem; globalIndex: number }[]>();
+
+    filtered.forEach((cmd, globalIndex) => {
+      const existing = groupMap.get(cmd.group);
+      if (existing) {
+        existing.push({ cmd, globalIndex });
+      } else {
+        const arr = [{ cmd, globalIndex }];
+        groupMap.set(cmd.group, arr);
+        groups.push({ name: cmd.group, items: arr });
+      }
+    });
+
+    return groups;
+  }, [filtered]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-md p-0 overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        <div
+          className="flex items-center gap-2 border-b border-border px-3"
+          onKeyDown={handleKeyDown}
+        >
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={handleQueryChange}
+            placeholder="Type a command..."
+            className="h-10 border-0 shadow-none focus-visible:ring-0 focus-visible:border-transparent"
+          />
+        </div>
+
+        <div ref={listRef} role="listbox" className="max-h-72 overflow-y-auto p-1">
+          {filtered.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">No results found.</p>
+          ) : (
+            groupedFiltered.map((group) => (
+              <div key={group.name} role="group" aria-label={group.name}>
+                <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                  {group.name}
+                </p>
+                {group.items.map(({ cmd, globalIndex }) => (
+                  <CommandOption
+                    key={cmd.id}
+                    cmd={cmd}
+                    isSelected={selectedIndex === globalIndex}
+                    onExecute={executeCommand}
+                    onSelect={setSelectedIndex}
+                    globalIndex={globalIndex}
+                  />
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/KeyboardShortcutsHelp.tsx
+++ b/frontend/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { HelpCircle, Keyboard } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from './ui/dialog';
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: { keys: string[]; description: string }[];
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+const modKey = isMac ? '⌘' : 'Ctrl';
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: 'Navigation',
+    shortcuts: [{ keys: [modKey, 'K'], description: 'Open Command Palette' }],
+  },
+  {
+    title: 'Note Editor',
+    shortcuts: [
+      { keys: [modKey, 'Enter'], description: 'Submit note / reply' },
+      { keys: ['Esc'], description: 'Cancel editing' },
+    ],
+  },
+  {
+    title: 'Mention (@)',
+    shortcuts: [
+      { keys: ['↑', '↓'], description: 'Navigate suggestions' },
+      { keys: ['Enter'], description: 'Select suggestion' },
+      { keys: ['Tab'], description: 'Select suggestion' },
+      { keys: ['Esc'], description: 'Close suggestions' },
+    ],
+  },
+  {
+    title: 'Search',
+    shortcuts: [
+      { keys: ['Enter'], description: 'Execute search' },
+      { keys: ['Esc'], description: 'Clear search' },
+    ],
+  },
+  {
+    title: 'Panel Layout',
+    shortcuts: [
+      { keys: ['Alt', '←'], description: 'Shrink left panel' },
+      { keys: ['Alt', '→'], description: 'Expand left panel' },
+      { keys: ['Alt', '0'], description: 'Reset to 50/50' },
+      { keys: ['Alt', '1'], description: 'Focus right panel (30/70)' },
+      { keys: ['Alt', '2'], description: 'Focus left panel (70/30)' },
+    ],
+  },
+  {
+    title: 'General',
+    shortcuts: [
+      { keys: [modKey, '/'], description: 'Toggle Scratch Pad' },
+      { keys: ['Esc'], description: 'Close dialog / sheet / scratch pad' },
+      { keys: ['?'], description: 'Show this help' },
+    ],
+  },
+];
+
+const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-1.5 rounded border border-border bg-muted text-xs font-mono text-muted-foreground shadow-sm">
+    {children}
+  </kbd>
+);
+
+export const KeyboardShortcutsHelp: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = useCallback(() => setOpen(true), []);
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  const handleGlobalKeyDown = useCallback((e: KeyboardEvent) => {
+    const target = e.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    const isInput =
+      target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+    if (e.key === '?' && !isInput && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      setOpen((prev) => !prev);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleGlobalKeyDown);
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
+  }, [handleGlobalKeyDown]);
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        aria-label="Keyboard shortcuts"
+        title="Keyboard shortcuts (?)"
+        data-testid="keyboard-shortcuts-help-button"
+      >
+        <HelpCircle className="h-4 w-4" />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="max-w-lg max-h-[80vh] overflow-y-auto"
+          role="dialog"
+          aria-modal="true"
+        >
+          <DialogClose onClose={handleClose} />
+          <DialogHeader>
+            <DialogTitle>
+              <span className="inline-flex items-center gap-2">
+                <Keyboard className="h-5 w-5" />
+                Keyboard Shortcuts
+              </span>
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="mt-4 space-y-5">
+            {SHORTCUT_GROUPS.map((group) => (
+              <div key={group.title}>
+                <h3 className="text-sm font-medium text-muted-foreground mb-2">{group.title}</h3>
+                <div className="space-y-1.5">
+                  {group.shortcuts.map((shortcut, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-accent/50"
+                    >
+                      <span className="text-sm text-foreground">{shortcut.description}</span>
+                      <div className="flex items-center gap-1 ml-4 shrink-0">
+                        {shortcut.keys.map((key, j) => (
+                          <React.Fragment key={j}>
+                            {j > 0 && <span className="text-muted-foreground text-xs">+</span>}
+                            <Kbd>{key}</Kbd>
+                          </React.Fragment>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import { ChannelList } from '@/components/channels/ChannelList';
 import { UserButton } from '@/components/UserButton';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { SettingsDropdown } from '@/components/SettingsDropdown';
+import { KeyboardShortcutsHelp } from '@/components/KeyboardShortcutsHelp';
 
 interface NavItemProps {
   icon: React.ReactNode;
@@ -95,6 +96,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
       <div className="flex items-center gap-2 border-t border-border px-3 py-2">
         <UserButton />
         <div className="flex-1" />
+        <KeyboardShortcutsHelp />
         <SettingsDropdown />
         <ThemeToggle />
       </div>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -35,18 +35,19 @@ export const Dialog: React.FC<DialogProps> = ({ open, onOpenChange, children }) 
   );
 };
 
-interface DialogContentProps {
+interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
 }
 
-export const DialogContent: React.FC<DialogContentProps> = ({ children, className }) => {
+export const DialogContent: React.FC<DialogContentProps> = ({ children, className, ...rest }) => {
   return (
     <div
       className={cn(
         'bg-background border rounded-lg shadow-lg w-full max-w-md p-6 animate-in fade-in-0 zoom-in-95',
         className
       )}
+      {...rest}
     >
       {children}
     </div>

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -4,6 +4,8 @@ export interface Shortcut {
   key: string;
   handler: () => void;
   description: string;
+  /** When true, the shortcut fires even when an input/textarea/contenteditable is focused. */
+  enableInInput?: boolean;
 }
 
 const isMac =
@@ -44,11 +46,10 @@ export const useKeyboardShortcuts = (shortcuts: Shortcut[]) => {
       if (!(e.target instanceof HTMLElement)) return;
 
       const { tagName, isContentEditable } = e.target;
-      if (tagName === 'INPUT' || tagName === 'TEXTAREA' || isContentEditable) {
-        return;
-      }
+      const isInInput = tagName === 'INPUT' || tagName === 'TEXTAREA' || isContentEditable;
 
       for (const shortcut of shortcutsRef.current) {
+        if (isInInput && !shortcut.enableInInput) continue;
         if (matchesShortcut(e, shortcut.key)) {
           e.preventDefault();
           shortcut.handler();


### PR DESCRIPTION
## Summary

- Add a searchable Command Palette (`Cmd+K`) for centralized navigation and actions, replacing browser-conflicting shortcuts (`Cmd+B/T/D/1~9`)
- Support keyboard navigation (arrow keys + Enter), real-time filtering, and activation from focused text inputs
- Update keyboard shortcuts help to reflect the new `Cmd+K` shortcut

## Changes

| File | Description |
|------|-------------|
| `CommandPalette.tsx` | New component: modal with search, grouped commands (Navigation / Channels / Actions), keyboard nav, ARIA roles |
| `AppLayout.tsx` | Remove `mod+B/T/D/1~9` shortcuts, add `mod+k` with `enableInInput: true`, render `<CommandPalette>` |
| `KeyboardShortcutsHelp.tsx` | Replace old navigation shortcuts with `Cmd+K → Open Command Palette` |
| `useKeyboardShortcuts.ts` | Add `enableInInput` flag to `Shortcut` interface so specific shortcuts work in text inputs |
| `dialog.tsx` | Extend `DialogContentProps` with `React.HTMLAttributes` for rest-prop forwarding |
| `Sidebar.tsx` | Add `KeyboardShortcutsHelp` button to sidebar footer |

## Test plan

- [ ] `Cmd+K` opens Command Palette from any context (including focused text inputs)
- [ ] Type to filter commands; arrow keys navigate, Enter executes, Esc closes
- [ ] Navigation commands (All Notes, Bookmarks, Tasks, Daily Notes) route correctly
- [ ] Channel list appears dynamically with correct color icons
- [ ] "Toggle Scratch Pad" action works from the palette
- [ ] `Cmd+B/T/D/1~9` no longer intercepted — browser default behavior restored
- [ ] `Cmd+/` still toggles Scratch Pad
- [ ] Keyboard shortcuts help (`?`) shows updated `Cmd+K` entry
- [ ] `bun run typecheck && bun run lint && bun run format` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)