### PR TITLE
fix: persist split view position across page reloads

### DIFF
--- a/frontend/src/layouts/SplitView.tsx
+++ b/frontend/src/layouts/SplitView.tsx
@@ -24,30 +24,25 @@ export const SplitView: React.FC<SplitViewProps> = ({
   className = '',
   showRight = true,
 }) => {
-  const [splitPosition, setSplitPosition] = useState(defaultSplitPosition);
+  // NOTE: Initialize split position from localStorage synchronously to avoid race conditions
+  const [splitPosition, setSplitPosition] = useState(() => {
+    const saved = localStorage.getItem('splitView.position');
+    if (saved) {
+      const position = parseFloat(saved);
+      if (position >= 20 && position <= 80) return position;
+    }
+    return defaultSplitPosition;
+  });
   const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const leftPanelRef = useRef<HTMLDivElement>(null);
   const rightPanelRef = useRef<HTMLDivElement>(null);
   const isDesktop = useMediaQuery('(min-width: 1024px)');
 
-  // NOTE: Load saved split position from localStorage
-  useEffect(() => {
-    const savedPosition = localStorage.getItem('splitView.position');
-    if (savedPosition) {
-      const position = parseFloat(savedPosition);
-      if (position >= 20 && position <= 80) {
-        setSplitPosition(position);
-      }
-    }
-  }, []);
-
   // NOTE: Save split position to localStorage
   useEffect(() => {
     localStorage.setItem('splitView.position', splitPosition.toString());
-    if (onSplitChange) {
-      onSplitChange(splitPosition);
-    }
+    onSplitChange?.(splitPosition);
   }, [splitPosition, onSplitChange]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- SplitView のパネル分割位置がリロードのたびにデフォルト値 (40%) にリセットされるバグを修正
- `useEffect` でのロードを `useState` の lazy initializer に変更し、save effect との競合を解消

## Root Cause
マウント時に2つの `useEffect` が順番に実行され、save effect が localStorage の値をデフォルト値で上書きしていた

## Test plan
- [ ] パネルをドラッグで分割位置を変更し、リロードして位置が保持されることを確認
- [ ] localStorage をクリアした状態でデフォルト値 (40%) が適用されることを確認
- [ ] 20%〜80% の範囲外の値が localStorage にあった場合、デフォルト値にフォールバックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)