### PR TITLE
feat: increase textarea auto-resize max from 3 to 10 rows

### DIFF
--- a/frontend/src/components/ui/text-input.tsx
+++ b/frontend/src/components/ui/text-input.tsx
@@ -62,7 +62,7 @@ export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
       [onKeyDown, onSubmit]
     );
 
-    // NOTE: Auto-resize textarea based on content (max 3 rows)
+    // NOTE: Auto-resize textarea based on content (max 10 rows)
     useEffect(() => {
       const textarea = textareaRef.current;
       if (!textarea) return;
@@ -70,7 +70,7 @@ export const TextInput = forwardRef<HTMLTextAreaElement, TextInputProps>(
       textarea.style.height = 'auto';
       const scrollHeight = textarea.scrollHeight;
       const lineHeight = parseInt(getComputedStyle(textarea).lineHeight);
-      const maxHeight = lineHeight * 3;
+      const maxHeight = lineHeight * 10;
 
       textarea.style.height = `${Math.min(scrollHeight, maxHeight)}px`;
     }, [value, textareaRef]);


### PR DESCRIPTION
## Summary
- TextInput の textarea 自動伸長の上限を3行から10行に拡大
- 長いメッセージ入力時にコンテンツが見やすくなる
- 新規入力・スレッド返信・メッセージ編集の3ケースすべてに適用（共通の TextInput コンポーネント）

## Test plan
- [ ] 新規メッセージ入力で4行以上のテキストを入力し、テキストエリアが伸びることを確認
- [ ] スレッド返信で同様に確認
- [ ] メッセージ編集モードで同様に確認
- [ ] 10行を超えるテキストでスクロールが発生し、画面を占拠しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)