### PR TITLE
fix: add cursor-pointer to all button elements

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -82,6 +82,10 @@
   * {
     @apply border-border outline-ring/50;
   }
+  button,
+  [role='button'] {
+    cursor: pointer;
+  }
   html,
   body,
   #root {


### PR DESCRIPTION
## Summary
- Add `cursor: pointer` globally for `<button>` and `[role="button"]` elements in `globals.css`
- Add `cursor-pointer` class to ShadCN `Button` component base styles for `asChild` usage

## Test plan
- [ ] Hover over ShadCN `Button` components (ThemeToggle, ThreadView close, etc.) and verify pointer cursor
- [ ] Hover over plain `<button>` elements (NoteList items, image toggle, search clear) and verify pointer cursor
- [ ] Verify disabled buttons still show default cursor (`disabled:pointer-events-none` handles this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)