### PR TITLE
fix: stabilize flaky E2E tests

### DIFF
--- a/frontend/tests/e2e/04-mention-note.spec.ts
+++ b/frontend/tests/e2e/04-mention-note.spec.ts
@@ -93,7 +93,9 @@ test.describe('Mention Note', () => {
     await selectNoteByContent(page, mentioningContent);
 
     // NOTE: Verify mention is displayed as a clickable link
-    const mentionLink = page.locator(`a:has-text("@${noteId}")`).first();
+    const mentionLink = page
+      .locator(`[data-testid="thread-view"] a:has-text("@${noteId}")`)
+      .first();
     await expect(mentionLink).toBeVisible();
 
     // NOTE: Verify it's an anchor tag with href

--- a/frontend/tests/e2e/09-tasks.spec.ts
+++ b/frontend/tests/e2e/09-tasks.spec.ts
@@ -24,8 +24,9 @@ test.describe('Tasks Page', () => {
   test('should auto-create task from note with checkbox syntax', async ({ page }) => {
     await page.goto('/');
 
-    // NOTE: Create a note with checkbox syntax
-    await createNote(page, '- [ ] Buy groceries');
+    // NOTE: Create a note with checkbox syntax (skip content verification because
+    // NoteContent renders "- [ ]" as a styled badge with CSS margin, not text space)
+    await createNote(page, '- [ ] Buy groceries', { skipContentVerification: true });
 
     // NOTE: Navigate to tasks page
     await page.getByRole('button', { name: 'Tasks' }).click();
@@ -41,8 +42,9 @@ test.describe('Tasks Page', () => {
   test('should show completed task from note with checked checkbox', async ({ page }) => {
     await page.goto('/');
 
-    // NOTE: Create a note with completed checkbox syntax
-    await createNote(page, '- [x] Already done');
+    // NOTE: Create a note with completed checkbox syntax (skip content verification because
+    // NoteContent renders "- [x]" as a styled badge with CSS margin, not text space)
+    await createNote(page, '- [x] Already done', { skipContentVerification: true });
 
     // NOTE: Navigate to tasks page
     await page.getByRole('button', { name: 'Tasks' }).click();

--- a/frontend/tests/e2e/10-scratch-pad.spec.ts
+++ b/frontend/tests/e2e/10-scratch-pad.spec.ts
@@ -28,13 +28,20 @@ test.describe('Scratch Pad', () => {
   test('should type content and auto-save', async ({ page }) => {
     await page.goto('/');
 
+    // NOTE: Set up response listener before opening scratch pad (GET fires on open)
+    const scratchPadLoaded = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/scratch-pad') && response.request().method() === 'GET',
+      { timeout: 10000 }
+    );
+
     // NOTE: Open scratch pad
     await page.keyboard.press(MOD_SLASH);
     const panel = page.getByTestId('scratch-pad-panel');
     await expect(panel).toHaveClass(/translate-x-0/);
 
-    // NOTE: Wait for initial GET scratch pad to complete
-    await page.waitForTimeout(1000);
+    // NOTE: Wait for initial GET scratch pad to complete before modifying content
+    await scratchPadLoaded;
 
     // NOTE: Clear existing content and type new content
     const textarea = page.getByTestId('scratch-pad-textarea');
@@ -49,9 +56,19 @@ test.describe('Scratch Pad', () => {
   test('should persist content after closing and reopening', async ({ page }) => {
     await page.goto('/');
 
+    // NOTE: Set up response listener before opening scratch pad (GET fires on open)
+    const scratchPadLoaded = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/scratch-pad') && response.request().method() === 'GET',
+      { timeout: 10000 }
+    );
+
     // NOTE: Open and clear any existing content, then type new content
     await page.keyboard.press(MOD_SLASH);
     const textarea = page.getByTestId('scratch-pad-textarea');
+
+    // NOTE: Wait for initial GET scratch pad to complete before clearing
+    await scratchPadLoaded;
     await textarea.click();
     await textarea.fill('');
     await textarea.pressSequentially('Persistent content', { delay: 20 });

--- a/frontend/tests/e2e/11-daily-notes.spec.ts
+++ b/frontend/tests/e2e/11-daily-notes.spec.ts
@@ -82,8 +82,10 @@ test.describe('Daily Notes', () => {
     // NOTE: Visit a past date - the API auto-creates a note from the default template
     await page.goto('/daily/2020-01-01');
 
-    // NOTE: Template content includes date and section headers, rendered in a <p> element
-    await expect(page.locator('p').filter({ hasText: '2020-01-01' })).toBeVisible();
-    await expect(page.locator('p').filter({ hasText: '## Today' })).toBeVisible();
+    // NOTE: Template content is rendered in a textarea, verify textarea contains expected text
+    const textarea = page.getByTestId('daily-note-textarea');
+    await expect(textarea).toBeVisible({ timeout: 10000 });
+    await expect(textarea).toHaveValue(/2020-01-01/);
+    await expect(textarea).toHaveValue(/## Today/);
   });
 });


### PR DESCRIPTION
## Summary
- Scope mention/delete button locators to `[data-testid="thread-view"]` to fix Playwright strict mode violations when multiple elements match across NoteList and ThreadView
- Replace `page.waitForFunction` DOM polling with Playwright auto-retry locators (`waitFor({ state: 'attached' })`) for more reliable note content detection under 6 parallel workers
- Replace `waitForTimeout(1000)` with API response interception (`waitForResponse`) in scratch pad tests to eliminate time-based flakiness
- Fix daily notes template assertion to check `<textarea>` value instead of non-existent `<p>` element
- Add `skipContentVerification` option to `createNote` for checkbox-rendered content (`- [ ]` / `- [x]`) where NoteContent's styled badge removes text spaces
- Increase API response timeouts from 5s to 15s to handle D1 database contention under parallel test execution

## Test plan
- [x] `bun run test:e2e` passes 54/54 (verified across 5 consecutive runs, 4/5 fully clean)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run format` produces no changes
- [ ] CI pipeline passes with `retries: 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)