### PR TITLE
feat: make authorId required across all note APIs

### DIFF
--- a/backend/drizzle/0004_make_author_id_required.sql
+++ b/backend/drizzle/0004_make_author_id_required.sql
@@ -1,0 +1,59 @@
+-- Migration: Make author_id NOT NULL on notes table
+--
+-- Decision: SQLite does not support ALTER COLUMN, so we recreate the table.
+-- Assumption: This is a single-user app; all orphaned notes are assigned to the first profile.
+-- Strategy:
+--   0. Guard: abort if NULL author_id exists but no profiles to backfill
+--   1. Fill existing NULL author_id with the sole existing user
+--   2. Recreate table with author_id NOT NULL
+--   3. Copy data, drop old, rename new
+--   4. Recreate indexes
+
+-- Step 0: Guard - fail early if NULL author_id exists but no profiles to backfill.
+-- Inserts into a NOT NULL column; if profiles is empty the subquery returns NULL → constraint error.
+CREATE TABLE IF NOT EXISTS _migration_check (val TEXT NOT NULL);
+--> statement-breakpoint
+INSERT INTO _migration_check
+  SELECT (SELECT id FROM profiles LIMIT 1)
+  WHERE (SELECT COUNT(*) FROM notes WHERE author_id IS NULL) > 0;
+--> statement-breakpoint
+DROP TABLE IF EXISTS _migration_check;
+--> statement-breakpoint
+
+-- Step 1: Backfill NULL author_id with the first existing profile (single-user assumption)
+UPDATE notes
+SET author_id = (SELECT id FROM profiles LIMIT 1)
+WHERE author_id IS NULL;
+--> statement-breakpoint
+
+-- Step 2: Create new table with author_id NOT NULL
+-- NOTE: parent_id FK omits table name so it resolves correctly after RENAME
+CREATE TABLE notes_new (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,
+  author_id TEXT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  parent_id TEXT,
+  channel_id TEXT REFERENCES channels(id) ON DELETE SET NULL,
+  created_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+  updated_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+  depth INTEGER DEFAULT 0 NOT NULL,
+  is_hidden INTEGER DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+
+-- Step 3: Copy all data from old table
+INSERT INTO notes_new (id, content, author_id, parent_id, channel_id, created_at, updated_at, depth, is_hidden)
+SELECT id, content, author_id, parent_id, channel_id, created_at, updated_at, depth, is_hidden
+FROM notes;
+--> statement-breakpoint
+
+-- Step 4: Drop old table and rename new
+DROP TABLE notes;
+--> statement-breakpoint
+ALTER TABLE notes_new RENAME TO notes;
+--> statement-breakpoint
+
+-- Step 5: Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_notes_channel ON notes(channel_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_notes_author ON notes(author_id);

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1765700000000,
       "tag": "0003_add_channels_and_enhancements",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1765800000000,
+      "tag": "0004_make_author_id_required",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/routes/mentions.ts
+++ b/backend/src/api/routes/mentions.ts
@@ -1,7 +1,7 @@
 import { createMentionService } from '../../services/mention';
 import { createNoteService } from '../../services/note';
 import { validateNoteId } from '../../middleware/validation';
-import { requireAuth } from '../../middleware/auth.middleware';
+import { requireAuth, getAuthUserId } from '../../middleware/auth.middleware';
 import { handleServiceResponse } from '../middleware/response-handler';
 import type { MentionsResponse } from '@thread-note/shared/types';
 import { serialize } from '../../types/api';
@@ -13,11 +13,14 @@ const app = createRouter()
     const db = c.get('db');
     const noteService = createNoteService({ db });
     const mentionService = createMentionService({ db });
+    const authorId = getAuthUserId(c);
 
     const { id } = c.req.valid('param');
 
     return handleServiceResponse(
-      noteService.getNoteById(id).andThen(() => mentionService.getMentionsWithNotes(id)),
+      noteService
+        .getNoteById(id, authorId)
+        .andThen(() => mentionService.getMentionsWithNotes(id, authorId)),
       c,
       (mentionsWithNotes) => {
         const response: MentionsResponse = {

--- a/backend/src/api/routes/notes.ts
+++ b/backend/src/api/routes/notes.ts
@@ -20,12 +20,13 @@ const app = createRouter()
   .get('/', requireAuth, validatePagination, async (c) => {
     const db = c.get('db');
     const noteService = createNoteService({ db });
+    const authorId = getAuthUserId(c);
 
     const { limit, offset } = c.req.valid('query');
     const includeHidden = c.req.query('includeHidden') === 'true';
 
     return handleServiceResponse(
-      noteService.getRootNotes(limit, offset, includeHidden),
+      noteService.getRootNotes(authorId, limit, offset, includeHidden),
       c,
       (d) => ({
         notes: d.notes.map(serialize),
@@ -60,12 +61,13 @@ const app = createRouter()
     const db = c.get('db');
     const noteService = createNoteService({ db });
     const threadService = createThreadService({ db });
+    const authorId = getAuthUserId(c);
     const { id } = c.req.valid('param');
     const includeThread = c.req.query('includeThread') !== 'false';
 
     return handleServiceResponse(
-      noteService.getNoteById(id).andThen((note) =>
-        (includeThread ? threadService.getThread(id) : okAsync([])).map((thread) => {
+      noteService.getNoteById(id, authorId).andThen((note) =>
+        (includeThread ? threadService.getThread(id, authorId) : okAsync([])).map((thread) => {
           const response: NoteDetailResponse = {
             note: serialize(note),
             thread: thread.map(serialize),
@@ -88,7 +90,7 @@ const app = createRouter()
 
     return handleServiceResponse(
       noteService
-        .updateNote(id, data)
+        .updateNote(id, authorId, data)
         .andThen((note) =>
           taskService.syncTasksFromNote(note.id, authorId, note.content).map(() => note)
         ),
@@ -101,19 +103,21 @@ const app = createRouter()
   .patch('/:id/hidden', requireAuth, validateNoteId, validateUpdateHidden, async (c) => {
     const db = c.get('db');
     const noteService = createNoteService({ db });
+    const authorId = getAuthUserId(c);
     const { id } = c.req.valid('param');
     const { isHidden } = c.req.valid('json');
 
-    return handleServiceResponse(noteService.updateHidden(id, isHidden), c, serialize);
+    return handleServiceResponse(noteService.updateHidden(id, authorId, isHidden), c, serialize);
   })
 
   // DELETE /api/notes/:id - Delete note (cascade)
   .delete('/:id', requireAuth, validateNoteId, async (c) => {
     const db = c.get('db');
     const noteService = createNoteService({ db });
+    const authorId = getAuthUserId(c);
     const { id } = c.req.valid('param');
 
-    return handleVoidResponse(noteService.deleteNote(id), c);
+    return handleVoidResponse(noteService.deleteNote(id, authorId), c);
   });
 
 export default app;

--- a/backend/src/api/routes/notes.ts
+++ b/backend/src/api/routes/notes.ts
@@ -45,7 +45,7 @@ const app = createRouter()
 
     return handleServiceResponse(
       noteService
-        .createNote(data)
+        .createNote({ ...data, authorId })
         .andThen((note) =>
           taskService.syncTasksFromNote(note.id, authorId, note.content).map(() => note)
         ),

--- a/backend/src/api/routes/search.ts
+++ b/backend/src/api/routes/search.ts
@@ -1,6 +1,6 @@
 import { createSearchService } from '../../services/search';
 import { validateSearch } from '../../middleware/validation';
-import { requireAuth } from '../../middleware/auth.middleware';
+import { requireAuth, getAuthUserId } from '../../middleware/auth.middleware';
 import { handleServiceResponse } from '../middleware/response-handler';
 import type { SearchResponse } from '@thread-note/shared/types';
 import { serialize } from '../../types/api';
@@ -11,13 +11,14 @@ const app = createRouter()
   .get('/search', requireAuth, validateSearch, async (c) => {
     const db = c.get('db');
     const searchService = createSearchService({ db });
+    const authorId = getAuthUserId(c);
 
     const { q, type, limit } = c.req.valid('query');
 
     const searchResult =
       type === 'mention'
-        ? searchService.searchByMention(q)
-        : searchService.searchByContent(q, limit);
+        ? searchService.searchByMention(q, authorId)
+        : searchService.searchByContent(authorId, q, limit);
 
     return handleServiceResponse(searchResult, c, (results) => {
       const response: SearchResponse = {

--- a/backend/src/db/seed.ts
+++ b/backend/src/db/seed.ts
@@ -1,6 +1,8 @@
-import { db, notes, mentions } from './index';
+import { db, notes, mentions, profiles } from './index';
 import { generateId } from '../utils/id-generator';
 import { sql } from 'drizzle-orm';
+
+const SEED_AUTHOR_ID = 'seed-user-001';
 
 // NOTE: Seed script for test data
 async function seed() {
@@ -16,11 +18,23 @@ async function seed() {
   // Then delete root notes
   await db.run(sql`DELETE FROM notes WHERE parent_id IS NULL`);
 
+  // Ensure seed profile exists
+  await db
+    .insert(profiles)
+    .values({
+      id: SEED_AUTHOR_ID,
+      displayName: 'Seed User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .onConflictDoNothing();
+
   // Create test data expected by tests
   // Test note with specific ID for contract tests
   await db.insert(notes).values({
     id: 'abc123',
     content: 'Test note for contract tests',
+    authorId: SEED_AUTHOR_ID,
     depth: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -30,6 +44,7 @@ async function seed() {
   await db.insert(notes).values({
     id: 'parent',
     content: 'Parent note for cascade test',
+    authorId: SEED_AUTHOR_ID,
     depth: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -39,6 +54,7 @@ async function seed() {
   await db.insert(notes).values({
     id: 'child1',
     content: 'Child note 1',
+    authorId: SEED_AUTHOR_ID,
     parentId: 'parent',
     depth: 1,
     createdAt: new Date(),
@@ -48,6 +64,7 @@ async function seed() {
   await db.insert(notes).values({
     id: 'child2',
     content: 'Child note 2',
+    authorId: SEED_AUTHOR_ID,
     parentId: 'parent',
     depth: 1,
     createdAt: new Date(),
@@ -58,6 +75,7 @@ async function seed() {
   await db.insert(notes).values({
     id: 'noment',
     content: 'Note with no mentions',
+    authorId: SEED_AUTHOR_ID,
     depth: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -68,6 +86,7 @@ async function seed() {
   await db.insert(notes).values({
     id: rootId,
     content: 'Welcome to Thread Notes! This is your first note.',
+    authorId: SEED_AUTHOR_ID,
     depth: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -78,6 +97,7 @@ async function seed() {
   await db.insert(notes).values({
     id: replyId,
     content: `This is a reply to @${rootId}`,
+    authorId: SEED_AUTHOR_ID,
     parentId: rootId,
     depth: 1,
     createdAt: new Date(),
@@ -97,6 +117,7 @@ async function seed() {
   await db.insert(notes).values({
     id: generateId(),
     content: 'This note contains the word test for search functionality',
+    authorId: SEED_AUTHOR_ID,
     depth: 0,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/backend/src/models/note.schema.ts
+++ b/backend/src/models/note.schema.ts
@@ -4,15 +4,17 @@ import { profiles } from './profile.schema';
 import { channels } from './channel.schema';
 
 // NOTE: Drizzle schema for Note entity with 1000 char limit (from clarifications)
-// NOTE: authorId is nullable for now, will be required after Clerk auth is fully implemented
+// NOTE: authorId is required - set from auth token on the server side
 export const notes = sqliteTable(
   'notes',
   {
     id: text('id').primaryKey(),
     content: text('content').notNull(),
-    authorId: text('author_id').references((): AnySQLiteColumn => profiles.id, {
-      onDelete: 'cascade',
-    }),
+    authorId: text('author_id')
+      .notNull()
+      .references((): AnySQLiteColumn => profiles.id, {
+        onDelete: 'cascade',
+      }),
     parentId: text('parent_id').references((): AnySQLiteColumn => notes.id, {
       onDelete: 'cascade',
     }),

--- a/backend/src/repositories/note.repository.ts
+++ b/backend/src/repositories/note.repository.ts
@@ -40,19 +40,27 @@ const attachReplyCount = (note: Note, replyCount: number): NoteWithReplyCount =>
 
 /** リポジトリインターフェース (依存性注入用) */
 export interface NoteRepository {
-  readonly findById: (id: string) => ResultAsync<Note | undefined, NoteError>;
+  readonly findById: (id: string, authorId: string) => ResultAsync<Note | undefined, NoteError>;
   readonly create: (note: NewNote) => ResultAsync<Note, NoteError>;
-  readonly update: (id: string, content: string) => ResultAsync<Note, NoteError>;
-  readonly updateHidden: (id: string, isHidden: boolean) => ResultAsync<Note, NoteError>;
+  readonly update: (id: string, authorId: string, content: string) => ResultAsync<Note, NoteError>;
+  readonly updateHidden: (
+    id: string,
+    authorId: string,
+    isHidden: boolean
+  ) => ResultAsync<Note, NoteError>;
   readonly findRootNotes: (
+    authorId: string,
     limit: number,
     offset: number,
     includeHidden?: boolean
   ) => ResultAsync<NoteWithReplyCount[], NoteError>;
-  readonly countRootNotes: (includeHidden?: boolean) => ResultAsync<number, NoteError>;
-  readonly findByParentId: (parentId: string) => ResultAsync<Note[], NoteError>;
-  readonly delete: (id: string) => ResultAsync<void, NoteError>;
-  readonly getThreadRecursive: (rootId: string) => ResultAsync<Note[], NoteError>;
+  readonly countRootNotes: (
+    authorId: string,
+    includeHidden?: boolean
+  ) => ResultAsync<number, NoteError>;
+  readonly findByParentId: (parentId: string, authorId: string) => ResultAsync<Note[], NoteError>;
+  readonly delete: (id: string, authorId: string) => ResultAsync<void, NoteError>;
+  readonly getThreadRecursive: (rootId: string, authorId: string) => ResultAsync<Note[], NoteError>;
 }
 
 // ==========================================
@@ -63,66 +71,86 @@ export interface NoteRepository {
  * ノートリポジトリを作成
  */
 export const createNoteRepository = ({ db }: { db: Database }): NoteRepository => {
-  // 内部ヘルパー: 子ノートを取得
-  const fetchChildren = (parentId: string): ResultAsync<Note[], NoteError> =>
+  // 内部ヘルパー: 子ノートを取得（authorId でフィルタ）
+  const fetchChildren = (parentId: string, authorId: string): ResultAsync<Note[], NoteError> =>
     dbQuery(
-      db.select().from(notes).where(eq(notes.parentId, parentId)).orderBy(asc(notes.createdAt)),
+      db
+        .select()
+        .from(notes)
+        .where(and(eq(notes.parentId, parentId), eq(notes.authorId, authorId)))
+        .orderBy(asc(notes.createdAt)),
       'Failed to fetch children'
     );
 
-  // 内部ヘルパー: 返信数を付与
-  const countReplies = (note: Note): ResultAsync<NoteWithReplyCount, NoteError> =>
+  // 内部ヘルパー: 返信数を付与（authorId でフィルタ）
+  const countReplies = (note: Note, authorId: string): ResultAsync<NoteWithReplyCount, NoteError> =>
     dbQuery(
-      db.select().from(notes).where(eq(notes.parentId, note.id)),
+      db
+        .select()
+        .from(notes)
+        .where(and(eq(notes.parentId, note.id), eq(notes.authorId, authorId))),
       'Failed to count replies'
     ).map((replies) => attachReplyCount(note, replies.length));
 
-  // 内部ヘルパー: ノートとその子孫を再帰的に取得
-  const fetchWithDescendants = (id: string): ResultAsync<Note[], NoteError> =>
-    dbQueryFirst(db.select().from(notes).where(eq(notes.id, id)), 'Failed to fetch note').andThen(
-      (note) =>
-        note
-          ? fetchChildren(id)
-              .andThen((children) =>
-                children.length === 0
-                  ? okAsync<Note[][], NoteError>([])
-                  : ResultAsync.combine(children.map((child) => fetchWithDescendants(child.id)))
-              )
-              .map((nestedChildren) => [note, ...nestedChildren.flat()])
-          : okAsync([])
+  // 内部ヘルパー: ノートとその子孫を再帰的に取得（authorId でフィルタ）
+  const fetchWithDescendants = (id: string, authorId: string): ResultAsync<Note[], NoteError> =>
+    dbQueryFirst(
+      db
+        .select()
+        .from(notes)
+        .where(and(eq(notes.id, id), eq(notes.authorId, authorId))),
+      'Failed to fetch note'
+    ).andThen((note) =>
+      note
+        ? fetchChildren(id, authorId)
+            .andThen((children) =>
+              children.length === 0
+                ? okAsync<Note[][], NoteError>([])
+                : ResultAsync.combine(
+                    children.map((child) => fetchWithDescendants(child.id, authorId))
+                  )
+            )
+            .map((nestedChildren) => [note, ...nestedChildren.flat()])
+        : okAsync([])
     );
 
   return {
-    findById: (id) =>
-      dbQueryFirst(db.select().from(notes).where(eq(notes.id, id)), 'Failed to find note'),
+    findById: (id, authorId) =>
+      dbQueryFirst(
+        db
+          .select()
+          .from(notes)
+          .where(and(eq(notes.id, id), eq(notes.authorId, authorId))),
+        'Failed to find note'
+      ),
 
     create: (note) =>
       dbInsertReturning(db.insert(notes).values(note).returning(), 'Failed to create note'),
 
-    update: (id, content) =>
+    update: (id, authorId, content) =>
       dbUpdateReturning(
         db
           .update(notes)
           .set({ content, updatedAt: new Date() })
-          .where(eq(notes.id, id))
+          .where(and(eq(notes.id, id), eq(notes.authorId, authorId)))
           .returning(),
         'Failed to update note'
       ),
 
-    updateHidden: (id, isHidden) =>
+    updateHidden: (id, authorId, isHidden) =>
       dbUpdateReturning(
         db
           .update(notes)
           .set({ isHidden, updatedAt: new Date() })
-          .where(eq(notes.id, id))
+          .where(and(eq(notes.id, id), eq(notes.authorId, authorId)))
           .returning(),
         'Failed to update note hidden status'
       ),
 
-    findRootNotes: (limit, offset, includeHidden = false) => {
+    findRootNotes: (authorId, limit, offset, includeHidden = false) => {
       const condition = includeHidden
-        ? isNull(notes.parentId)
-        : and(isNull(notes.parentId), eq(notes.isHidden, false));
+        ? and(isNull(notes.parentId), eq(notes.authorId, authorId))
+        : and(isNull(notes.parentId), eq(notes.isHidden, false), eq(notes.authorId, authorId));
 
       return dbQuery(
         db
@@ -133,13 +161,15 @@ export const createNoteRepository = ({ db }: { db: Database }): NoteRepository =
           .limit(limit)
           .offset(offset),
         'Failed to find root notes'
-      ).andThen((rootNotes) => ResultAsync.combine(rootNotes.map(countReplies)));
+      ).andThen((rootNotes) =>
+        ResultAsync.combine(rootNotes.map((note) => countReplies(note, authorId)))
+      );
     },
 
-    countRootNotes: (includeHidden = false) => {
+    countRootNotes: (authorId, includeHidden = false) => {
       const condition = includeHidden
-        ? isNull(notes.parentId)
-        : and(isNull(notes.parentId), eq(notes.isHidden, false));
+        ? and(isNull(notes.parentId), eq(notes.authorId, authorId))
+        : and(isNull(notes.parentId), eq(notes.isHidden, false), eq(notes.authorId, authorId));
 
       return dbQuery(
         db
@@ -151,21 +181,25 @@ export const createNoteRepository = ({ db }: { db: Database }): NoteRepository =
       );
     },
 
-    findByParentId: (parentId) =>
+    findByParentId: (parentId, authorId) =>
       dbQuery(
-        db.select().from(notes).where(eq(notes.parentId, parentId)),
+        db
+          .select()
+          .from(notes)
+          .where(and(eq(notes.parentId, parentId), eq(notes.authorId, authorId))),
         'Failed to find notes by parent id'
       ),
 
-    delete: (id) =>
+    delete: (id, authorId) =>
       dbQuery(
         db
           .delete(notes)
-          .where(eq(notes.id, id))
+          .where(and(eq(notes.id, id), eq(notes.authorId, authorId)))
           .then(() => undefined),
         'Failed to delete note'
       ),
 
-    getThreadRecursive: (rootId) => fetchWithDescendants(rootId).map(sortByDepthAndCreatedAt),
+    getThreadRecursive: (rootId, authorId) =>
+      fetchWithDescendants(rootId, authorId).map(sortByDepthAndCreatedAt),
   };
 };

--- a/backend/src/repositories/search.repository.ts
+++ b/backend/src/repositories/search.repository.ts
@@ -6,7 +6,7 @@
  */
 
 import { ResultAsync } from 'neverthrow';
-import { like, desc } from 'drizzle-orm';
+import { like, desc, and, eq } from 'drizzle-orm';
 import { notes, type Note, type Database } from '../db';
 import type { NoteError } from '../errors/domain-errors';
 import { dbQuery } from './helpers';
@@ -16,7 +16,11 @@ import { dbQuery } from './helpers';
 // ==========================================
 
 export interface SearchRepository {
-  readonly searchByContent: (query: string, limit?: number) => ResultAsync<Note[], NoteError>;
+  readonly searchByContent: (
+    authorId: string,
+    query: string,
+    limit?: number
+  ) => ResultAsync<Note[], NoteError>;
 }
 
 // ==========================================
@@ -27,12 +31,12 @@ export interface SearchRepository {
  * 検索リポジトリを作成
  */
 export const createSearchRepository = ({ db }: { db: Database }): SearchRepository => ({
-  searchByContent: (query, limit = 20) =>
+  searchByContent: (authorId, query, limit = 20) =>
     dbQuery(
       db
         .select()
         .from(notes)
-        .where(like(notes.content, `%${query}%`))
+        .where(and(like(notes.content, `%${query}%`), eq(notes.authorId, authorId)))
         .orderBy(desc(notes.updatedAt))
         .limit(limit),
       'Failed to search notes by content'

--- a/backend/src/services/bookmark/bookmark.service.ts
+++ b/backend/src/services/bookmark/bookmark.service.ts
@@ -23,7 +23,7 @@ export const createBookmarkService = ({ db }: { db: Database }): BookmarkService
   return {
     toggleBookmark: (noteId, authorId) =>
       noteRepo
-        .findById(noteId)
+        .findById(noteId, authorId)
         .andThen(ensureNoteExists(noteId))
         .andThen(() =>
           bookmarkRepo

--- a/backend/src/services/daily-note/daily-note.service.spec.ts
+++ b/backend/src/services/daily-note/daily-note.service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../tests/preload';
+import { db, notes, mentions, profiles, dailyNotes, templates } from '../../db';
+import { createDailyNoteService } from '.';
+
+const TEST_AUTHOR_ID = 'test-author-id';
+
+describe('DailyNoteService', () => {
+  const prepareServices = () => {
+    const service = createDailyNoteService({ db });
+    return { service };
+  };
+
+  beforeEach(async () => {
+    await db.delete(mentions);
+    await db.delete(dailyNotes);
+    await db.delete(notes);
+    await db.delete(templates);
+    await db.delete(profiles);
+    await db.insert(profiles).values({
+      id: TEST_AUTHOR_ID,
+      displayName: 'Test User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  describe('getDailyNote', () => {
+    it('should create a daily note with the correct authorId', async () => {
+      const { service } = prepareServices();
+      const today = '2026-02-16';
+
+      const result = await service.getDailyNote(TEST_AUTHOR_ID, today);
+      expect(result.isOk()).toBe(true);
+
+      const { note } = result._unsafeUnwrap();
+      expect(note.authorId).toBe(TEST_AUTHOR_ID);
+    });
+
+    it('should return existing daily note on second call', async () => {
+      const { service } = prepareServices();
+      const today = '2026-02-16';
+
+      const first = await service.getDailyNote(TEST_AUTHOR_ID, today);
+      const second = await service.getDailyNote(TEST_AUTHOR_ID, today);
+
+      expect(first.isOk()).toBe(true);
+      expect(second.isOk()).toBe(true);
+
+      const firstNote = first._unsafeUnwrap().note;
+      const secondNote = second._unsafeUnwrap().note;
+      expect(firstNote.id).toBe(secondNote.id);
+      expect(secondNote.authorId).toBe(TEST_AUTHOR_ID);
+    });
+  });
+});

--- a/backend/src/services/daily-note/daily-note.service.ts
+++ b/backend/src/services/daily-note/daily-note.service.ts
@@ -72,7 +72,9 @@ export const createDailyNoteService = ({ db }: { db: Database }): DailyNoteServi
     getDailyNote: (authorId, date, templateId) =>
       dailyNoteRepo.findByAuthorAndDate(authorId, date).andThen((existing) =>
         existing
-          ? noteService.getNoteById(existing.noteId).map((note) => ({ dailyNote: existing, note }))
+          ? noteService
+              .getNoteById(existing.noteId, authorId)
+              .map((note) => ({ dailyNote: existing, note }))
           : (templateId
               ? templateRepo.findById(templateId).andThen(ensureTemplateExists(templateId))
               : getOrCreateDefaultTemplate(authorId)

--- a/backend/src/services/daily-note/daily-note.service.ts
+++ b/backend/src/services/daily-note/daily-note.service.ts
@@ -78,7 +78,11 @@ export const createDailyNoteService = ({ db }: { db: Database }): DailyNoteServi
               : getOrCreateDefaultTemplate(authorId)
             ).andThen((template) =>
               noteService
-                .createNote({ content: processTemplate(template.content, date), isHidden: false })
+                .createNote({
+                  content: processTemplate(template.content, date),
+                  authorId,
+                  isHidden: false,
+                })
                 .andThen((note) =>
                   dailyNoteRepo
                     .create({

--- a/backend/src/services/mention/mention.service.spec.ts
+++ b/backend/src/services/mention/mention.service.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import '../../../tests/preload';
-import { db, notes, mentions } from '../../db';
+import { db, notes, mentions, profiles } from '../../db';
 import { createMentionService } from '.';
 import { generateId } from '../../utils/id-generator';
+
+const TEST_AUTHOR_ID = 'test-author-id';
 
 describe('MentionService', () => {
   const prepareServices = () => {
@@ -43,6 +45,13 @@ describe('MentionService', () => {
   beforeEach(async () => {
     await db.delete(mentions);
     await db.delete(notes);
+    await db.delete(profiles);
+    await db.insert(profiles).values({
+      id: TEST_AUTHOR_ID,
+      displayName: 'Test User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
   });
 
   describe('getMentions', () => {
@@ -54,6 +63,7 @@ describe('MentionService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'Test note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -76,6 +86,7 @@ describe('MentionService', () => {
         {
           id: targetNoteId,
           content: 'Target note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -84,6 +95,7 @@ describe('MentionService', () => {
         {
           id: sourceNoteId,
           content: `Mentioning @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -118,6 +130,7 @@ describe('MentionService', () => {
         {
           id: targetNoteId,
           content: 'Target note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -126,6 +139,7 @@ describe('MentionService', () => {
         {
           id: sourceNoteId1,
           content: `First mention @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -134,6 +148,7 @@ describe('MentionService', () => {
         {
           id: sourceNoteId2,
           content: `Second mention @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -173,6 +188,7 @@ describe('MentionService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'Test note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -195,6 +211,7 @@ describe('MentionService', () => {
         {
           id: targetNoteId,
           content: 'Target note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -203,6 +220,7 @@ describe('MentionService', () => {
         {
           id: sourceNoteId,
           content: `Source note @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -238,6 +256,7 @@ describe('MentionService', () => {
         {
           id: noteId1,
           content: 'Note 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -246,6 +265,7 @@ describe('MentionService', () => {
         {
           id: noteId2,
           content: 'Note 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -267,6 +287,7 @@ describe('MentionService', () => {
         {
           id: noteId1,
           content: 'Note 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -275,6 +296,7 @@ describe('MentionService', () => {
         {
           id: noteId2,
           content: 'Note 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -305,6 +327,7 @@ describe('MentionService', () => {
         {
           id: noteId1,
           content: 'Note 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -313,6 +336,7 @@ describe('MentionService', () => {
         {
           id: noteId2,
           content: 'Note 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -321,6 +345,7 @@ describe('MentionService', () => {
         {
           id: noteId3,
           content: 'Note 3',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -360,6 +385,7 @@ describe('MentionService', () => {
         {
           id: noteId1,
           content: 'Note 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -368,6 +394,7 @@ describe('MentionService', () => {
         {
           id: noteId2,
           content: 'Note 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -376,6 +403,7 @@ describe('MentionService', () => {
         {
           id: noteId3,
           content: 'Note 3',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,

--- a/backend/src/services/mention/mention.service.ts
+++ b/backend/src/services/mention/mention.service.ts
@@ -31,9 +31,10 @@ export const createMentionService = ({ db }: { db: Database }): MentionServiceHa
   const mentionRepo = createMentionRepository({ db });
 
   return {
-    getMentions: (toNoteId) => mentionRepo.findByToNoteId(toNoteId),
+    getMentions: (toNoteId, authorId) => mentionRepo.findByToNoteId(toNoteId, authorId),
 
-    getMentionsWithNotes: (toNoteId) => mentionRepo.getMentionsWithNotes(toNoteId),
+    getMentionsWithNotes: (toNoteId, authorId) =>
+      mentionRepo.getMentionsWithNotes(toNoteId, authorId),
 
     validateMentions: (fromNoteId, toNoteIds) =>
       mentionRepo

--- a/backend/src/services/mention/types.ts
+++ b/backend/src/services/mention/types.ts
@@ -28,10 +28,13 @@ export interface MentionWithNote {
  * メンション管理のための公開API。
  */
 export interface MentionServiceHandle {
-  /** 指定ノートへのメンション一覧を取得 */
-  readonly getMentions: (toNoteId: string) => ResultAsync<Mention[], NoteError>;
-  /** 指定ノートへのメンションとソースノート情報を取得 */
-  readonly getMentionsWithNotes: (toNoteId: string) => ResultAsync<MentionWithNote[], NoteError>;
+  /** 指定ノートへのメンション一覧を取得（authorId でフィルタ） */
+  readonly getMentions: (toNoteId: string, authorId: string) => ResultAsync<Mention[], NoteError>;
+  /** 指定ノートへのメンションとソースノート情報を取得（authorId でフィルタ） */
+  readonly getMentionsWithNotes: (
+    toNoteId: string,
+    authorId: string
+  ) => ResultAsync<MentionWithNote[], NoteError>;
   /** メンションの循環参照を検証 */
   readonly validateMentions: (
     fromNoteId: string,

--- a/backend/src/services/note/note.service.ts
+++ b/backend/src/services/note/note.service.ts
@@ -86,6 +86,7 @@ export const createNoteService = ({ db }: { db: Database }): NoteServiceHandle =
           ? okAsync({
               id: noteId,
               content: input.content,
+              authorId: input.authorId,
               parentId: input.parentId,
               depth,
               mentionIds: [],
@@ -94,6 +95,7 @@ export const createNoteService = ({ db }: { db: Database }): NoteServiceHandle =
           : validateCircularReference(noteId, mentionIds).map(() => ({
               id: noteId,
               content: input.content,
+              authorId: input.authorId,
               parentId: input.parentId,
               depth,
               mentionIds,
@@ -131,6 +133,7 @@ export const createNoteService = ({ db }: { db: Database }): NoteServiceHandle =
     const newNote: NewNote = {
       id: data.id,
       content: data.content,
+      authorId: data.authorId,
       parentId: data.parentId,
       depth: data.depth,
       isHidden: data.isHidden,

--- a/backend/src/services/note/types.ts
+++ b/backend/src/services/note/types.ts
@@ -15,6 +15,7 @@ import type { NoteError } from '../../errors/domain-errors';
 /** ノート作成のための入力データ */
 export interface CreateNoteInput {
   readonly content: string;
+  readonly authorId: string;
   readonly parentId?: string;
   readonly isHidden?: boolean;
 }
@@ -43,6 +44,7 @@ export interface PaginatedNotes {
 export interface ValidatedNoteData {
   readonly id: string;
   readonly content: string;
+  readonly authorId: string;
   readonly parentId?: string;
   readonly depth: number;
   readonly mentionIds: string[];

--- a/backend/src/services/note/types.ts
+++ b/backend/src/services/note/types.ts
@@ -65,18 +65,27 @@ export interface ValidatedNoteData {
 export interface NoteServiceHandle {
   /** ノートを作成 */
   readonly createNote: (input: CreateNoteInput) => ResultAsync<Note, NoteError>;
-  /** IDでノートを取得 */
-  readonly getNoteById: (id: string) => ResultAsync<Note, NoteError>;
-  /** ルートノートを取得 */
+  /** IDでノートを取得（authorId による所有権チェック） */
+  readonly getNoteById: (id: string, authorId: string) => ResultAsync<Note, NoteError>;
+  /** ルートノートを取得（authorId でフィルタ） */
   readonly getRootNotes: (
+    authorId: string,
     limit?: number,
     offset?: number,
     includeHidden?: boolean
   ) => ResultAsync<PaginatedNotes, NoteError>;
-  /** ノートを更新 */
-  readonly updateNote: (id: string, input: UpdateNoteInput) => ResultAsync<Note, NoteError>;
-  /** ノートの hidden 状態を更新 */
-  readonly updateHidden: (id: string, isHidden: boolean) => ResultAsync<Note, NoteError>;
-  /** ノートを削除（カスケード） */
-  readonly deleteNote: (id: string) => ResultAsync<void, NoteError>;
+  /** ノートを更新（authorId による所有権チェック） */
+  readonly updateNote: (
+    id: string,
+    authorId: string,
+    input: UpdateNoteInput
+  ) => ResultAsync<Note, NoteError>;
+  /** ノートの hidden 状態を更新（authorId による所有権チェック） */
+  readonly updateHidden: (
+    id: string,
+    authorId: string,
+    isHidden: boolean
+  ) => ResultAsync<Note, NoteError>;
+  /** ノートを削除（カスケード、authorId による所有権チェック） */
+  readonly deleteNote: (id: string, authorId: string) => ResultAsync<void, NoteError>;
 }

--- a/backend/src/services/scratch-pad/scratch-pad.service.spec.ts
+++ b/backend/src/services/scratch-pad/scratch-pad.service.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../tests/preload';
+import { db, notes, mentions, profiles, scratchPads } from '../../db';
+import { createScratchPadService } from '.';
+
+const TEST_AUTHOR_ID = 'test-author-id';
+
+describe('ScratchPadService', () => {
+  const prepareServices = () => {
+    const service = createScratchPadService({ db });
+    return { service };
+  };
+
+  beforeEach(async () => {
+    await db.delete(mentions);
+    await db.delete(notes);
+    await db.delete(scratchPads);
+    await db.delete(profiles);
+    await db.insert(profiles).values({
+      id: TEST_AUTHOR_ID,
+      displayName: 'Test User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  describe('convertToNote', () => {
+    it('should create a note with the correct authorId', async () => {
+      const { service } = prepareServices();
+
+      // NOTE: Create scratch pad with content
+      await service.updateScratchPad(TEST_AUTHOR_ID, 'Scratch pad content');
+
+      const result = await service.convertToNote(TEST_AUTHOR_ID);
+      expect(result.isOk()).toBe(true);
+
+      const note = result._unsafeUnwrap();
+      expect(note.authorId).toBe(TEST_AUTHOR_ID);
+      expect(note.content).toBe('Scratch pad content');
+    });
+
+    it('should fail when scratch pad is empty', async () => {
+      const { service } = prepareServices();
+
+      const result = await service.convertToNote(TEST_AUTHOR_ID);
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/backend/src/services/scratch-pad/scratch-pad.service.ts
+++ b/backend/src/services/scratch-pad/scratch-pad.service.ts
@@ -54,7 +54,7 @@ export const createScratchPadService = ({ db }: { db: Database }): ScratchPadSer
           !scratchPad || !scratchPad.content.trim()
             ? errAsync(contentEmptyError())
             : noteService
-                .createNote({ content: scratchPad.content, isHidden: false })
+                .createNote({ content: scratchPad.content, authorId, isHidden: false })
                 .andThen((note) => scratchPadRepo.update(scratchPad.id, '').map(() => note))
         ),
   };

--- a/backend/src/services/search/search.service.spec.ts
+++ b/backend/src/services/search/search.service.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import '../../../tests/preload';
-import { db, notes, mentions } from '../../db';
+import { db, notes, mentions, profiles } from '../../db';
 import { createSearchService } from '.';
 import { generateId } from '../../utils/id-generator';
+
+const TEST_AUTHOR_ID = 'test-author-id';
 
 describe('SearchService', () => {
   const prepareServices = () => {
@@ -34,6 +36,13 @@ describe('SearchService', () => {
   beforeEach(async () => {
     await db.delete(mentions);
     await db.delete(notes);
+    await db.delete(profiles);
+    await db.insert(profiles).values({
+      id: TEST_AUTHOR_ID,
+      displayName: 'Test User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
   });
 
   describe('searchByContent', () => {
@@ -53,6 +62,7 @@ describe('SearchService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'This is a test note about TypeScript',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -73,6 +83,7 @@ describe('SearchService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'JavaScript Tutorial',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -93,6 +104,7 @@ describe('SearchService', () => {
         {
           id: generateId(),
           content: 'First note about JavaScript',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -101,6 +113,7 @@ describe('SearchService', () => {
         {
           id: generateId(),
           content: 'Second note about JavaScript frameworks',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -109,6 +122,7 @@ describe('SearchService', () => {
         {
           id: generateId(),
           content: 'Note about Python',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -129,6 +143,7 @@ describe('SearchService', () => {
         await db.insert(notes).values({
           id: generateId(),
           content: `Test note number ${i}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: new Date(now.getTime() + i * 1000),
@@ -149,6 +164,7 @@ describe('SearchService', () => {
         await db.insert(notes).values({
           id: generateId(),
           content: `Search note ${i}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: new Date(now.getTime() + i * 1000),
@@ -171,6 +187,7 @@ describe('SearchService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'Test note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -193,6 +210,7 @@ describe('SearchService', () => {
         {
           id: targetNoteId,
           content: 'Target note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -201,6 +219,7 @@ describe('SearchService', () => {
         {
           id: sourceNoteId,
           content: `Source note @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -234,6 +253,7 @@ describe('SearchService', () => {
         {
           id: targetNoteId,
           content: 'Target note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -242,6 +262,7 @@ describe('SearchService', () => {
         {
           id: sourceNoteId1,
           content: `First source @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -250,6 +271,7 @@ describe('SearchService', () => {
         {
           id: sourceNoteId2,
           content: `Second source @${targetNoteId}`,
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,

--- a/backend/src/services/search/search.service.ts
+++ b/backend/src/services/search/search.service.ts
@@ -22,10 +22,13 @@ export const createSearchService = ({ db }: { db: Database }): SearchServiceHand
   const mentionRepo = createMentionRepository({ db });
 
   return {
-    searchByContent: (query, limit = 20) => searchRepo.searchByContent(query, limit),
+    searchByContent: (authorId, query, limit = 20) =>
+      searchRepo.searchByContent(authorId, query, limit),
 
-    searchByMention: (noteId) =>
-      mentionRepo.getMentionsWithNotes(noteId).map((mentions) => mentions.map((m) => m.notes)),
+    searchByMention: (noteId, authorId) =>
+      mentionRepo
+        .getMentionsWithNotes(noteId, authorId)
+        .map((mentions) => mentions.map((m) => m.notes)),
   };
 };
 

--- a/backend/src/services/search/types.ts
+++ b/backend/src/services/search/types.ts
@@ -18,8 +18,12 @@ import type { NoteError } from '../../errors/domain-errors';
  * 検索機能のための公開API。
  */
 export interface SearchServiceHandle {
-  /** コンテンツでノートを検索 */
-  readonly searchByContent: (query: string, limit?: number) => ResultAsync<Note[], NoteError>;
-  /** メンションでノートを検索（指定ノートをメンションしているノート一覧） */
-  readonly searchByMention: (noteId: string) => ResultAsync<Note[], NoteError>;
+  /** コンテンツでノートを検索（authorId でフィルタ） */
+  readonly searchByContent: (
+    authorId: string,
+    query: string,
+    limit?: number
+  ) => ResultAsync<Note[], NoteError>;
+  /** メンションでノートを検索（指定ノートをメンションしているノート一覧、authorId でフィルタ） */
+  readonly searchByMention: (noteId: string, authorId: string) => ResultAsync<Note[], NoteError>;
 }

--- a/backend/src/services/thread/thread.service.spec.ts
+++ b/backend/src/services/thread/thread.service.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import '../../../tests/preload';
-import { db, notes, mentions } from '../../db';
+import { db, notes, mentions, profiles } from '../../db';
 import { createThreadService } from '.';
 import { generateId } from '../../utils/id-generator';
+
+const TEST_AUTHOR_ID = 'test-author-id';
 
 describe('ThreadService', () => {
   const prepareServices = () => {
@@ -34,6 +36,13 @@ describe('ThreadService', () => {
   beforeEach(async () => {
     await db.delete(mentions);
     await db.delete(notes);
+    await db.delete(profiles);
+    await db.insert(profiles).values({
+      id: TEST_AUTHOR_ID,
+      displayName: 'Test User',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
   });
 
   describe('getThread', () => {
@@ -51,6 +60,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'Root note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -73,6 +83,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: rootId,
         content: 'Root note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -82,6 +93,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: childId,
         content: 'Child note',
+        authorId: TEST_AUTHOR_ID,
         parentId: rootId,
         depth: 1,
         createdAt: now,
@@ -105,6 +117,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: rootId,
         content: 'Root note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -114,6 +127,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: childId,
         content: 'Child note',
+        authorId: TEST_AUTHOR_ID,
         parentId: rootId,
         depth: 1,
         createdAt: now,
@@ -139,6 +153,7 @@ describe('ThreadService', () => {
         {
           id: rootId,
           content: 'Root note',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -147,6 +162,7 @@ describe('ThreadService', () => {
         {
           id: childId1,
           content: 'Child 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: rootId,
           depth: 1,
           createdAt: new Date(now.getTime() + 1000),
@@ -155,6 +171,7 @@ describe('ThreadService', () => {
         {
           id: childId2,
           content: 'Child 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: rootId,
           depth: 1,
           createdAt: new Date(now.getTime() + 2000),
@@ -179,6 +196,7 @@ describe('ThreadService', () => {
         {
           id: thread1RootId,
           content: 'Thread 1 root',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -187,6 +205,7 @@ describe('ThreadService', () => {
         {
           id: thread1ChildId,
           content: 'Thread 1 child',
+          authorId: TEST_AUTHOR_ID,
           parentId: thread1RootId,
           depth: 1,
           createdAt: now,
@@ -195,6 +214,7 @@ describe('ThreadService', () => {
         {
           id: thread2RootId,
           content: 'Thread 2 root',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -218,6 +238,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: noteId,
         content: 'Root note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -239,6 +260,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: parentId,
         content: 'Parent note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -248,6 +270,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: childId,
         content: 'Child note',
+        authorId: TEST_AUTHOR_ID,
         parentId: parentId,
         depth: 1,
         createdAt: now,
@@ -272,6 +295,7 @@ describe('ThreadService', () => {
       await db.insert(notes).values({
         id: parentId,
         content: 'Parent note',
+        authorId: TEST_AUTHOR_ID,
         parentId: null,
         depth: 0,
         createdAt: now,
@@ -282,6 +306,7 @@ describe('ThreadService', () => {
         {
           id: childId1,
           content: 'Child 1',
+          authorId: TEST_AUTHOR_ID,
           parentId: parentId,
           depth: 1,
           createdAt: now,
@@ -290,6 +315,7 @@ describe('ThreadService', () => {
         {
           id: childId2,
           content: 'Child 2',
+          authorId: TEST_AUTHOR_ID,
           parentId: parentId,
           depth: 1,
           createdAt: now,
@@ -298,6 +324,7 @@ describe('ThreadService', () => {
         {
           id: childId3,
           content: 'Child 3',
+          authorId: TEST_AUTHOR_ID,
           parentId: parentId,
           depth: 1,
           createdAt: now,
@@ -322,6 +349,7 @@ describe('ThreadService', () => {
         {
           id: grandparentId,
           content: 'Grandparent',
+          authorId: TEST_AUTHOR_ID,
           parentId: null,
           depth: 0,
           createdAt: now,
@@ -330,6 +358,7 @@ describe('ThreadService', () => {
         {
           id: parentId,
           content: 'Parent',
+          authorId: TEST_AUTHOR_ID,
           parentId: grandparentId,
           depth: 1,
           createdAt: now,
@@ -338,6 +367,7 @@ describe('ThreadService', () => {
         {
           id: grandchildId,
           content: 'Grandchild',
+          authorId: TEST_AUTHOR_ID,
           parentId: parentId,
           depth: 2,
           createdAt: now,

--- a/backend/src/services/thread/types.ts
+++ b/backend/src/services/thread/types.ts
@@ -18,8 +18,8 @@ import type { NoteError } from '../../errors/domain-errors';
  * スレッド階層管理のための公開API。
  */
 export interface ThreadServiceHandle {
-  /** ノートが属するスレッド全体を取得（ルートから全子孫） */
-  readonly getThread: (noteId: string) => ResultAsync<Note[], NoteError>;
-  /** ノートの直接の子ノートを取得 */
-  readonly getChildren: (noteId: string) => ResultAsync<Note[], NoteError>;
+  /** ノートが属するスレッド全体を取得（ルートから全子孫、authorId でフィルタ） */
+  readonly getThread: (noteId: string, authorId: string) => ResultAsync<Note[], NoteError>;
+  /** ノートの直接の子ノートを取得（authorId でフィルタ） */
+  readonly getChildren: (noteId: string, authorId: string) => ResultAsync<Note[], NoteError>;
 }

--- a/backend/tests/integration/mentions.routes.test.ts
+++ b/backend/tests/integration/mentions.routes.test.ts
@@ -30,6 +30,8 @@ type TestBindings = {
   APP_DOMAIN: string;
 };
 
+const TEST_USER_ID = 'test_user_123';
+
 describe('Mentions Routes Integration Tests', () => {
   let app: Hono<{ Bindings: TestBindings }>;
 
@@ -37,23 +39,35 @@ describe('Mentions Routes Integration Tests', () => {
   const clearTables = async () => {
     await env.DB.exec('DELETE FROM mentions');
     await env.DB.exec('DELETE FROM notes');
+    await env.DB.exec('DELETE FROM profiles');
+  };
+
+  // Helper to insert a profile directly via D1
+  const insertProfile = async (id: string, displayName = 'Test User') => {
+    await env.DB.prepare(
+      "INSERT OR IGNORE INTO profiles (id, display_name, created_at, updated_at) VALUES (?, ?, datetime('now'), datetime('now'))"
+    )
+      .bind(id, displayName)
+      .run();
   };
 
   // Helper to insert a note directly via D1
   const insertNote = async (note: {
     id: string;
     content: string;
+    authorId?: string;
     parentId: string | null;
     depth: number;
     createdAt: Date;
     updatedAt: Date;
   }) => {
     await env.DB.prepare(
-      'INSERT INTO notes (id, content, parent_id, depth, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+      'INSERT INTO notes (id, content, author_id, parent_id, depth, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
     )
       .bind(
         note.id,
         note.content,
+        note.authorId ?? TEST_USER_ID,
         note.parentId,
         note.depth,
         note.createdAt.toISOString(),
@@ -87,13 +101,16 @@ describe('Mentions Routes Integration Tests', () => {
     // Clear database before each test
     await clearTables();
 
+    // Create test user profile (required by FK constraint)
+    await insertProfile(TEST_USER_ID, 'Test User');
+
     // Reset mocks
     vi.clearAllMocks();
 
     // Mock authentication to succeed by default
     mockAuthenticateRequest.mockResolvedValue({
       isAuthenticated: true,
-      toAuth: () => ({ userId: 'test_user_123', sessionId: 'test_session_456' }),
+      toAuth: () => ({ userId: TEST_USER_ID, sessionId: 'test_session_456' }),
     });
 
     // Create a fresh Hono app with the mentions routes


### PR DESCRIPTION
## Summary
- Add database migration to make `author_id` NOT NULL on notes table (with data migration for existing rows)
- Make `authorId` required across schema, services, repositories, and API routes
- Enforce `authorId` filtering on all note queries (list, search, mentions, threads) so users only see their own data

## Test plan
- [x] Unit tests updated for all services (note, mention, search, thread, daily-note, scratch-pad)
- [x] Integration tests updated for all API routes (notes, mentions, search)
- [ ] Verify migration works on existing database with NULL author_id rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)