### PR TITLE
feat: Server Actions for channels, posts, replies, search

### DIFF
--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/db";
+import { profiles } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function getAuthProfile() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("Unauthorized");
+  }
+
+  const [profile] = await db
+    .select()
+    .from(profiles)
+    .where(eq(profiles.authUserId, user.id));
+
+  if (!profile) {
+    throw new Error("Profile not found");
+  }
+
+  return profile;
+}

--- a/src/app/actions/channels.ts
+++ b/src/app/actions/channels.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { channels } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { getAuthProfile } from "./auth";
+
+export async function getChannels() {
+  const profile = await getAuthProfile();
+  return db
+    .select()
+    .from(channels)
+    .where(eq(channels.authorId, profile.id))
+    .orderBy(asc(channels.sortOrder), asc(channels.name));
+}
+
+export async function getChannel(id: string) {
+  const profile = await getAuthProfile();
+  const [channel] = await db
+    .select()
+    .from(channels)
+    .where(eq(channels.id, id));
+
+  if (!channel || channel.authorId !== profile.id) {
+    return null;
+  }
+
+  return channel;
+}
+
+export async function createChannel(formData: FormData) {
+  const profile = await getAuthProfile();
+  const name = formData.get("name") as string;
+  const description = (formData.get("description") as string) || null;
+
+  if (!name?.trim()) {
+    return { error: "Channel name is required" };
+  }
+
+  const existing = await db
+    .select()
+    .from(channels)
+    .where(eq(channels.authorId, profile.id));
+
+  const maxSortOrder = existing.reduce(
+    (max, ch) => Math.max(max, ch.sortOrder),
+    -1,
+  );
+
+  await db.insert(channels).values({
+    name: name.trim(),
+    description: description?.trim() || null,
+    sortOrder: maxSortOrder + 1,
+    authorId: profile.id,
+  });
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function updateChannel(id: string, formData: FormData) {
+  await getAuthProfile();
+  const name = formData.get("name") as string;
+  const description = (formData.get("description") as string) || null;
+
+  if (!name?.trim()) {
+    return { error: "Channel name is required" };
+  }
+
+  await db
+    .update(channels)
+    .set({
+      name: name.trim(),
+      description: description?.trim() || null,
+    })
+    .where(eq(channels.id, id));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function deleteChannel(id: string) {
+  await getAuthProfile();
+
+  await db.delete(channels).where(eq(channels.id, id));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function reorderChannels(orderedIds: string[]) {
+  await getAuthProfile();
+
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < orderedIds.length; i++) {
+      await tx
+        .update(channels)
+        .set({ sortOrder: i })
+        .where(eq(channels.id, orderedIds[i]));
+    }
+  });
+
+  revalidatePath("/");
+  return { success: true };
+}

--- a/src/app/actions/post-replies.ts
+++ b/src/app/actions/post-replies.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { postReplies } from "@/db/schema";
+import { eq, asc, sql, inArray } from "drizzle-orm";
+import { getAuthProfile } from "./auth";
+
+export async function getReplies(postId: string) {
+  await getAuthProfile();
+  return db
+    .select()
+    .from(postReplies)
+    .where(eq(postReplies.postId, postId))
+    .orderBy(asc(postReplies.createdAt));
+}
+
+export async function getReplyCount(postId: string) {
+  await getAuthProfile();
+  const [result] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(postReplies)
+    .where(eq(postReplies.postId, postId));
+  return result?.count ?? 0;
+}
+
+export async function getReplyCounts(postIds: string[]) {
+  if (postIds.length === 0) return {};
+
+  await getAuthProfile();
+  const results = await db
+    .select({
+      postId: postReplies.postId,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(postReplies)
+    .where(inArray(postReplies.postId, postIds))
+    .groupBy(postReplies.postId);
+
+  const counts: Record<string, number> = {};
+  for (const r of results) {
+    counts[r.postId] = r.count;
+  }
+  return counts;
+}
+
+export async function createReply(
+  postId: string,
+  content: string,
+  channelId: string,
+) {
+  const profile = await getAuthProfile();
+
+  if (!content?.trim()) {
+    return { error: "Content is required" };
+  }
+
+  const [reply] = await db
+    .insert(postReplies)
+    .values({
+      postId,
+      content: content.trim(),
+      authorId: profile.id,
+    })
+    .returning();
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true, id: reply.id };
+}
+
+export async function updateReply(
+  id: string,
+  content: string,
+  channelId: string,
+) {
+  await getAuthProfile();
+
+  if (!content?.trim()) {
+    return { error: "Content is required" };
+  }
+
+  await db
+    .update(postReplies)
+    .set({ content: content.trim() })
+    .where(eq(postReplies.id, id));
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true };
+}
+
+export async function deleteReply(id: string, channelId: string) {
+  await getAuthProfile();
+
+  await db.delete(postReplies).where(eq(postReplies.id, id));
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true };
+}

--- a/src/app/actions/posts.ts
+++ b/src/app/actions/posts.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { posts } from "@/db/schema";
+import { eq, asc } from "drizzle-orm";
+import { getAuthProfile } from "./auth";
+
+export async function getPosts(channelId: string) {
+  await getAuthProfile();
+  return db
+    .select()
+    .from(posts)
+    .where(eq(posts.channelId, channelId))
+    .orderBy(asc(posts.createdAt));
+}
+
+export async function getPost(id: string) {
+  await getAuthProfile();
+  const [post] = await db.select().from(posts).where(eq(posts.id, id));
+  return post ?? null;
+}
+
+export async function createPost(channelId: string, content: string) {
+  const profile = await getAuthProfile();
+
+  if (!content?.trim()) {
+    return { error: "Content is required" };
+  }
+
+  const [post] = await db
+    .insert(posts)
+    .values({
+      channelId,
+      content: content.trim(),
+      authorId: profile.id,
+    })
+    .returning();
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true, id: post.id };
+}
+
+export async function updatePost(
+  id: string,
+  channelId: string,
+  content: string,
+) {
+  await getAuthProfile();
+
+  if (!content?.trim()) {
+    return { error: "Content is required" };
+  }
+
+  await db
+    .update(posts)
+    .set({ content: content.trim() })
+    .where(eq(posts.id, id));
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true };
+}
+
+export async function deletePost(id: string, channelId: string) {
+  await getAuthProfile();
+
+  await db.delete(posts).where(eq(posts.id, id));
+
+  revalidatePath(`/channels/${channelId}`);
+  return { success: true };
+}

--- a/src/app/actions/search.ts
+++ b/src/app/actions/search.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { db } from "@/db";
+import { posts, postReplies, channels } from "@/db/schema";
+import { sql, eq } from "drizzle-orm";
+import { getAuthProfile } from "./auth";
+
+export type SearchResult = {
+  id: string;
+  content: string;
+  channelId: string;
+  channelName: string;
+  createdAt: Date;
+  type: "post" | "reply";
+  similarity: number;
+};
+
+export async function searchPosts(query: string): Promise<SearchResult[]> {
+  const profile = await getAuthProfile();
+
+  if (!query?.trim()) return [];
+
+  const trimmed = query.trim();
+
+  const postResults = await db
+    .select({
+      id: posts.id,
+      content: posts.content,
+      channelId: posts.channelId,
+      channelName: channels.name,
+      createdAt: posts.createdAt,
+      similarity: sql<number>`similarity(${posts.content}, ${trimmed})`,
+    })
+    .from(posts)
+    .innerJoin(channels, eq(posts.channelId, channels.id))
+    .where(
+      sql`${posts.authorId} = ${profile.id} AND ${posts.content} % ${trimmed}`,
+    )
+    .orderBy(sql`similarity(${posts.content}, ${trimmed}) DESC`)
+    .limit(20);
+
+  const replyResults = await db
+    .select({
+      id: postReplies.id,
+      content: postReplies.content,
+      channelId: channels.id,
+      channelName: channels.name,
+      createdAt: postReplies.createdAt,
+      similarity:
+        sql<number>`similarity(${postReplies.content}, ${trimmed})`,
+    })
+    .from(postReplies)
+    .innerJoin(posts, eq(postReplies.postId, posts.id))
+    .innerJoin(channels, eq(posts.channelId, channels.id))
+    .where(
+      sql`${postReplies.authorId} = ${profile.id} AND ${postReplies.content} % ${trimmed}`,
+    )
+    .orderBy(sql`similarity(${postReplies.content}, ${trimmed}) DESC`)
+    .limit(20);
+
+  const results: SearchResult[] = [
+    ...postResults.map((r) => ({ ...r, type: "post" as const })),
+    ...replyResults.map((r) => ({ ...r, type: "reply" as const })),
+  ];
+
+  results.sort((a, b) => b.similarity - a.similarity);
+
+  return results.slice(0, 20);
+}


### PR DESCRIPTION
## Summary
- `auth.ts`: `getAuthProfile()` — Supabase Auth + profiles テーブル認証ヘルパー
- `channels.ts`: CRUD + `reorderChannels` (sort_order 一括更新)
- `posts.ts`: CRUD (チャネルスコープ revalidation)
- `post-replies.ts`: CRUD + `getReplyCount` / `getReplyCounts` (複数一括)
- `search.ts`: pg_trgm `similarity()` による posts + post_replies 横断検索

## PR Chain
**PR 3/6** — Server Actions

```
PR 1 ✅ → PR 2 ✅ → PR 3 (this) → PR 4 (UI) → PR 5 (PWA) / PR 6 (Migration)
```

## Test plan
- [x] `bun run build` — 成功
- [x] `bunx --bun eslint src/` — エラーなし
- [ ] Supabase 接続後に各 Action の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)