### PR TITLE
fix: exclude scripts from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "src/sw.ts"]
+  "exclude": ["node_modules", "src/sw.ts", "scripts"]
 }


### PR DESCRIPTION
Exclude scripts/ directory from tsconfig to fix Vercel build (Bun types not available in CI)