### PR TITLE
perf: reduce unnecessary re-renders and duplicate data fetching

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,10 @@ const withSerwist = withSerwistInit({
   swDest: "public/sw.js",
 });
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: ["lucide-react"],
+  },
+};
 
 export default withSerwist(nextConfig);

--- a/src/app/(app)/channels/[id]/page.tsx
+++ b/src/app/(app)/channels/[id]/page.tsx
@@ -17,13 +17,12 @@ export default async function ChannelPage({
 }) {
   const { id } = await params;
   const { highlight } = await searchParams;
-  const channel = await getChannel(id);
+  const [channel, posts] = await Promise.all([getChannel(id), getPosts(id)]);
 
   if (!channel) {
     notFound();
   }
 
-  const posts = await getPosts(id);
   const postIds = posts.map((p) => p.id);
   const threadReplyCounts = await getReplyCounts(postIds);
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,14 +1,29 @@
+import dynamic from "next/dynamic";
+import { getChannels } from "@/app/actions/channels";
 import { Sidebar } from "@/components/sidebar";
 import { MobileHeader } from "@/components/mobile-header";
-import { SearchModal } from "@/components/search-modal";
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+const SearchModal = dynamic(
+  () =>
+    import("@/components/search-modal").then((mod) => ({
+      default: mod.SearchModal,
+    })),
+  { ssr: false },
+);
+
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const channelList = await getChannels();
+
   return (
     <>
       <div className="flex h-screen">
-        <Sidebar />
+        <Sidebar channels={channelList} />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <MobileHeader />
+          <MobileHeader channels={channelList} />
           <main className="flex-1 overflow-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/app/actions/channels.ts
+++ b/src/app/actions/channels.ts
@@ -5,9 +5,10 @@ import { db } from "@/db";
 import { channels } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { getAuthProfile } from "./auth";
+import { getCachedAuthProfile } from "@/lib/cached-auth";
 
 export async function getChannels() {
-  const profile = await getAuthProfile();
+  const profile = await getCachedAuthProfile();
   return db
     .select()
     .from(channels)
@@ -16,11 +17,8 @@ export async function getChannels() {
 }
 
 export async function getChannel(id: string) {
-  const profile = await getAuthProfile();
-  const [channel] = await db
-    .select()
-    .from(channels)
-    .where(eq(channels.id, id));
+  const profile = await getCachedAuthProfile();
+  const [channel] = await db.select().from(channels).where(eq(channels.id, id));
 
   if (!channel || channel.authorId !== profile.id) {
     return null;

--- a/src/app/actions/post-replies.ts
+++ b/src/app/actions/post-replies.ts
@@ -5,9 +5,10 @@ import { db } from "@/db";
 import { postReplies } from "@/db/schema";
 import { eq, asc, sql, inArray } from "drizzle-orm";
 import { getAuthProfile } from "./auth";
+import { getCachedAuthProfile } from "@/lib/cached-auth";
 
 export async function getReplies(postId: string) {
-  await getAuthProfile();
+  await getCachedAuthProfile();
   return db
     .select()
     .from(postReplies)
@@ -16,7 +17,7 @@ export async function getReplies(postId: string) {
 }
 
 export async function getReplyCount(postId: string) {
-  await getAuthProfile();
+  await getCachedAuthProfile();
   const [result] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(postReplies)
@@ -27,7 +28,7 @@ export async function getReplyCount(postId: string) {
 export async function getReplyCounts(postIds: string[]) {
   if (postIds.length === 0) return {};
 
-  await getAuthProfile();
+  await getCachedAuthProfile();
   const results = await db
     .select({
       postId: postReplies.postId,

--- a/src/app/actions/posts.ts
+++ b/src/app/actions/posts.ts
@@ -5,9 +5,10 @@ import { db } from "@/db";
 import { posts } from "@/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { getAuthProfile } from "./auth";
+import { getCachedAuthProfile } from "@/lib/cached-auth";
 
 export async function getPosts(channelId: string) {
-  await getAuthProfile();
+  await getCachedAuthProfile();
   return db
     .select()
     .from(posts)
@@ -16,7 +17,7 @@ export async function getPosts(channelId: string) {
 }
 
 export async function getPost(id: string) {
-  await getAuthProfile();
+  await getCachedAuthProfile();
   const [post] = await db.select().from(posts).where(eq(posts.id, id));
   return post ?? null;
 }

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -1,10 +1,17 @@
+import { memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-export function MarkdownRenderer({ content }: { content: string }) {
+const REMARK_PLUGINS = [remarkGfm];
+
+export const MarkdownRenderer = memo(function MarkdownRenderer({
+  content,
+}: {
+  content: string;
+}) {
   return (
     <div className="prose prose-sm dark:prose-invert max-w-none break-words [&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-medium [&_h1]:mt-3 [&_h1]:mb-1 [&_h2]:mt-2 [&_h2]:mb-1 [&_h3]:mt-2 [&_h3]:mb-1 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted [&_pre]:p-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-sm [&_a]:text-primary [&_a]:underline">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
     </div>
   );
-}
+});

--- a/src/components/mobile-header.tsx
+++ b/src/components/mobile-header.tsx
@@ -1,13 +1,20 @@
-import { getChannels } from "@/app/actions/channels";
 import { MobileSidebar } from "./mobile-sidebar";
 import { ThemeToggle } from "./theme-toggle";
 
-export async function MobileHeader() {
-  const channelList = await getChannels();
+type Channel = {
+  id: string;
+  name: string;
+  description: string | null;
+  sortOrder: number;
+  authorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
+export function MobileHeader({ channels }: { channels: Channel[] }) {
   return (
     <header className="flex h-14 items-center border-b px-4 md:hidden">
-      <MobileSidebar channels={channelList} />
+      <MobileSidebar channels={channels} />
       <h1 className="ml-3 flex-1 text-lg font-semibold">Thread</h1>
       <ThemeToggle />
     </header>

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { memo, useEffect, useRef, useState } from "react";
 import { Pencil, Trash2, Check, X, MessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -26,14 +25,16 @@ function formatTimestamp(date: Date) {
   });
 }
 
-export function PostItem({
+export const PostItem = memo(function PostItem({
   post,
   threadReplyCount,
   highlight,
+  onOpenThread,
 }: {
   post: Post;
   threadReplyCount?: number;
   highlight?: boolean;
+  onOpenThread: (postId: string) => void;
 }) {
   const highlightRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
@@ -51,8 +52,6 @@ export function PostItem({
 
   const [editContent, setEditContent] = useState(post.content);
   const [deleting, setDeleting] = useState(false);
-  const router = useRouter();
-  const searchParams = useSearchParams();
 
   const isEdited = post.createdAt.getTime() !== post.updatedAt.getTime();
 
@@ -82,18 +81,12 @@ export function PostItem({
     }
   };
 
-  const handleOpenThread = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("thread", post.id);
-    router.push(`?${params.toString()}`);
-  };
-
   return (
     <div
       ref={highlightRef}
       id={`post-${post.id}`}
-      className={`group relative cursor-pointer border-b border-border/50 px-3 py-3 transition-colors duration-1000 hover:bg-muted/50`}
-      onClick={!editing ? handleOpenThread : undefined}
+      className={`group relative cursor-pointer border-b border-border/50 px-3 py-3 transition-colors duration-150 hover:bg-muted/50`}
+      onClick={!editing ? () => onOpenThread(post.id) : undefined}
     >
       <div className="flex items-baseline gap-2">
         <span className="text-xs font-medium text-muted-foreground">
@@ -132,7 +125,7 @@ export function PostItem({
 
       {threadReplyCount !== undefined && threadReplyCount > 0 && !editing && (
         <button
-          onClick={handleOpenThread}
+          onClick={() => onOpenThread(post.id)}
           className="mt-1 text-xs font-medium text-primary hover:underline"
         >
           {threadReplyCount} {threadReplyCount === 1 ? "reply" : "replies"}
@@ -148,7 +141,7 @@ export function PostItem({
             variant="ghost"
             size="icon"
             className="h-6 w-6"
-            onClick={handleOpenThread}
+            onClick={() => onOpenThread(post.id)}
             aria-label="Reply in thread"
             title="Reply in thread"
           >
@@ -182,4 +175,4 @@ export function PostItem({
       )}
     </div>
   );
-}
+});

--- a/src/components/post-list.tsx
+++ b/src/components/post-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { PostItem } from "@/components/post-item";
 import { MessageCircle } from "lucide-react";
 
@@ -23,6 +24,8 @@ export function PostList({
   highlightPostId?: string;
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (highlightPostId) {
@@ -34,6 +37,15 @@ export function PostList({
     }
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [posts.length, highlightPostId]);
+
+  const handleOpenThread = useCallback(
+    (postId: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("thread", postId);
+      router.push(`?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
 
   if (posts.length === 0) {
     return (
@@ -53,6 +65,7 @@ export function PostList({
             post={post}
             threadReplyCount={threadReplyCounts?.[post.id]}
             highlight={post.id === highlightPostId}
+            onOpenThread={handleOpenThread}
           />
         ))}
         <div ref={bottomRef} />

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,11 +1,18 @@
-import { getChannels } from "@/app/actions/channels";
 import { ChannelList } from "./channel-list";
 import { CreateChannelDialog } from "./create-channel-dialog";
 import { ThemeToggle } from "./theme-toggle";
 
-export async function Sidebar() {
-  const channelList = await getChannels();
+type Channel = {
+  id: string;
+  name: string;
+  description: string | null;
+  sortOrder: number;
+  authorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
+export function Sidebar({ channels }: { channels: Channel[] }) {
   return (
     <aside className="hidden w-64 shrink-0 border-r bg-muted/30 md:flex md:flex-col">
       <div className="flex h-14 items-center justify-between border-b px-4">
@@ -20,7 +27,7 @@ export async function Sidebar() {
           <CreateChannelDialog />
         </div>
         <nav className="px-2">
-          <ChannelList channels={channelList} />
+          <ChannelList channels={channels} />
         </nav>
       </div>
     </aside>

--- a/src/lib/cached-auth.ts
+++ b/src/lib/cached-auth.ts
@@ -1,0 +1,27 @@
+import { cache } from "react";
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/db";
+import { profiles } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export const getCachedAuthProfile = cache(async () => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("Unauthorized");
+  }
+
+  const [profile] = await db
+    .select()
+    .from(profiles)
+    .where(eq(profiles.authUserId, user.id));
+
+  if (!profile) {
+    throw new Error("Profile not found");
+  }
+
+  return profile;
+});


### PR DESCRIPTION
## Summary
- **PostItem の useSearchParams 除去**: スレッド開閉時に全投稿が再レンダリングされる問題を解消。PostList で一括管理し、onOpenThread コールバックで渡す設計に変更
- **React.memo 適用**: PostItem・MarkdownRenderer をメモ化し、props が変わらない限り再レンダリングをスキップ
- **認証チェックの cache() メモ化**: React.cache() で getAuthProfile をリクエスト単位でメモ化（1リクエストあたり最大6回→1回に削減）
- **データフェッチの並列化**: getChannel + getPosts を Promise.all で同時実行
- **getChannels の重複解消**: Sidebar/MobileHeader で2回呼ばれていた getChannels を layout で1回取得し props で配布
- **SearchModal の遅延ロード**: next/dynamic で初期バンドルから分離
- **optimizePackageImports**: lucide-react のバレルファイル最適化を有効化
- **トランジション短縮**: PostItem のホバー duration-1000 → duration-150

## Test plan
- [ ] チャンネルページでスレッドの開閉がスムーズに動作すること
- [ ] 投稿の編集・削除が正常に機能すること
- [ ] Cmd+K で検索モーダルが開くこと
- [ ] Sidebar・MobileHeader にチャンネル一覧が正しく表示されること
- [ ] ページ遷移が以前より速くなっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)