### PR TITLE
feat: add stocks/stockTags schema and notes CRUD with sidebar

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const withSerwist = withSerwistInit({
 });
 
 const nextConfig: NextConfig = {
+  turbopack: {},
   experimental: {
     optimizePackageImports: ["lucide-react"],
   },

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,16 +1,8 @@
-import dynamic from "next/dynamic";
 import { getChannels } from "@/app/actions/channels";
 import { getNotes } from "@/app/actions/stocks";
 import { Sidebar } from "@/components/sidebar";
 import { MobileHeader } from "@/components/mobile-header";
-
-const SearchModal = dynamic(
-  () =>
-    import("@/components/search-modal").then((mod) => ({
-      default: mod.SearchModal,
-    })),
-  { ssr: false },
-);
+import { SearchModal } from "@/components/search-modal";
 
 export default async function AppLayout({
   children,

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic";
 import { getChannels } from "@/app/actions/channels";
+import { getNotes } from "@/app/actions/stocks";
 import { Sidebar } from "@/components/sidebar";
 import { MobileHeader } from "@/components/mobile-header";
 
@@ -16,14 +17,17 @@ export default async function AppLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const channelList = await getChannels();
+  const [channelList, noteList] = await Promise.all([
+    getChannels(),
+    getNotes("note"),
+  ]);
 
   return (
     <>
       <div className="flex h-screen">
-        <Sidebar channels={channelList} />
+        <Sidebar channels={channelList} notes={noteList} />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <MobileHeader channels={channelList} />
+          <MobileHeader channels={channelList} notes={noteList} />
           <main className="flex-1 overflow-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/app/(app)/notes/[id]/page.tsx
+++ b/src/app/(app)/notes/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { getNoteById, getGroups, getTags } from "@/app/actions/stocks";
+import { NoteEditor } from "@/components/note-editor";
+
+export default async function NoteDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const [note, groups, tagSuggestions] = await Promise.all([
+    getNoteById(id),
+    getGroups(),
+    getTags(),
+  ]);
+
+  if (!note) {
+    notFound();
+  }
+
+  return (
+    <NoteEditor note={note} groups={groups} tagSuggestions={tagSuggestions} />
+  );
+}

--- a/src/app/(app)/notes/new/page.tsx
+++ b/src/app/(app)/notes/new/page.tsx
@@ -1,0 +1,8 @@
+import { getGroups, getTags } from "@/app/actions/stocks";
+import { NoteEditor } from "@/components/note-editor";
+
+export default async function NewNotePage() {
+  const [groups, tagSuggestions] = await Promise.all([getGroups(), getTags()]);
+
+  return <NoteEditor groups={groups} tagSuggestions={tagSuggestions} />;
+}

--- a/src/app/(app)/notes/page.tsx
+++ b/src/app/(app)/notes/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { getNotes } from "@/app/actions/stocks";
+import { NoteList } from "@/components/note-list";
+
+export default async function NotesPage() {
+  const notes = await getNotes("note");
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold">Notes</h2>
+        <Link
+          href="/notes/new"
+          className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow-xs hover:bg-primary/90"
+        >
+          New Note
+        </Link>
+      </div>
+
+      {notes.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground">
+          <p>No notes yet.</p>
+          <p className="mt-1 text-sm">Create your first note to get started.</p>
+        </div>
+      ) : (
+        <NoteList notes={notes} />
+      )}
+    </div>
+  );
+}

--- a/src/app/actions/stocks.ts
+++ b/src/app/actions/stocks.ts
@@ -1,0 +1,206 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/db";
+import { stocks, stockTags } from "@/db/schema";
+import { eq, and, isNotNull, asc, desc, inArray } from "drizzle-orm";
+import { getAuthProfile } from "./auth";
+import { getCachedAuthProfile } from "@/lib/cached-auth";
+
+export type NoteWithTags = {
+  id: string;
+  status: string;
+  title: string;
+  content: string;
+  group: string | null;
+  sourcePostIds: string;
+  sourceChannelId: string | null;
+  authorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  tags: string[];
+};
+
+export async function getNotes(status?: string): Promise<NoteWithTags[]> {
+  const profile = await getCachedAuthProfile();
+
+  const conditions = [eq(stocks.authorId, profile.id)];
+  if (status) {
+    conditions.push(eq(stocks.status, status));
+  }
+
+  const noteRows = await db
+    .select()
+    .from(stocks)
+    .where(and(...conditions))
+    .orderBy(desc(stocks.updatedAt));
+
+  if (noteRows.length === 0) return [];
+
+  const noteIds = noteRows.map((n) => n.id);
+  const allTags = await db
+    .select()
+    .from(stockTags)
+    .where(inArray(stockTags.stockId, noteIds));
+
+  const tagsByNoteId = new Map<string, string[]>();
+  for (const row of noteRows) {
+    tagsByNoteId.set(row.id, []);
+  }
+  for (const t of allTags) {
+    tagsByNoteId.get(t.stockId)?.push(t.tag);
+  }
+
+  return noteRows.map((note) => ({
+    ...note,
+    tags: tagsByNoteId.get(note.id) ?? [],
+  }));
+}
+
+export async function getNoteById(id: string): Promise<NoteWithTags | null> {
+  const profile = await getCachedAuthProfile();
+
+  const [note] = await db.select().from(stocks).where(eq(stocks.id, id));
+
+  if (!note || note.authorId !== profile.id) {
+    return null;
+  }
+
+  const tags = await db
+    .select()
+    .from(stockTags)
+    .where(eq(stockTags.stockId, id));
+
+  return {
+    ...note,
+    tags: tags.map((t) => t.tag),
+  };
+}
+
+export async function createNote(data: {
+  title: string;
+  content: string;
+  group?: string | null;
+  tags?: string[];
+}) {
+  const profile = await getAuthProfile();
+
+  if (!data.title?.trim()) {
+    return { error: "Title is required" };
+  }
+
+  const [note] = await db
+    .insert(stocks)
+    .values({
+      status: "note",
+      title: data.title.trim(),
+      content: data.content?.trim() ?? "",
+      group: data.group?.trim() || null,
+      authorId: profile.id,
+    })
+    .returning();
+
+  if (data.tags && data.tags.length > 0) {
+    const uniqueTags = [
+      ...new Set(data.tags.map((t) => t.toLowerCase().trim()).filter(Boolean)),
+    ];
+    if (uniqueTags.length > 0) {
+      await db.insert(stockTags).values(
+        uniqueTags.map((tag) => ({
+          stockId: note.id,
+          tag,
+        })),
+      );
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true, id: note.id };
+}
+
+export async function updateNote(
+  id: string,
+  data: {
+    title: string;
+    content: string;
+    group?: string | null;
+    tags?: string[];
+  },
+) {
+  await getAuthProfile();
+
+  if (!data.title?.trim()) {
+    return { error: "Title is required" };
+  }
+
+  await db
+    .update(stocks)
+    .set({
+      title: data.title.trim(),
+      content: data.content?.trim() ?? "",
+      group: data.group?.trim() || null,
+    })
+    .where(eq(stocks.id, id));
+
+  if (data.tags !== undefined) {
+    await db.delete(stockTags).where(eq(stockTags.stockId, id));
+
+    const uniqueTags = [
+      ...new Set(data.tags.map((t) => t.toLowerCase().trim()).filter(Boolean)),
+    ];
+    if (uniqueTags.length > 0) {
+      await db.insert(stockTags).values(
+        uniqueTags.map((tag) => ({
+          stockId: id,
+          tag,
+        })),
+      );
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function deleteNote(id: string) {
+  await getAuthProfile();
+
+  await db.delete(stocks).where(eq(stocks.id, id));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function getGroups(): Promise<string[]> {
+  const profile = await getCachedAuthProfile();
+
+  const rows = await db
+    .select({ group: stocks.group })
+    .from(stocks)
+    .where(and(eq(stocks.authorId, profile.id), isNotNull(stocks.group)))
+    .orderBy(asc(stocks.group));
+
+  return [
+    ...new Set(rows.map((r) => r.group).filter((g): g is string => g !== null)),
+  ];
+}
+
+export async function getTags(): Promise<string[]> {
+  const profile = await getCachedAuthProfile();
+
+  const noteIds = await db
+    .select({ id: stocks.id })
+    .from(stocks)
+    .where(eq(stocks.authorId, profile.id));
+
+  if (noteIds.length === 0) return [];
+
+  const ids = noteIds.map((n) => n.id);
+  const allTags = await db
+    .select({ tag: stockTags.tag })
+    .from(stockTags)
+    .where(inArray(stockTags.stockId, ids))
+    .orderBy(asc(stockTags.tag));
+
+  return [...new Set(allTags.map((t) => t.tag))];
+}

--- a/src/components/group-select.tsx
+++ b/src/components/group-select.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface GroupSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  groups: string[];
+}
+
+export function GroupSelect({ value, onChange, groups }: GroupSelectProps) {
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = groups.filter(
+    (g) => g.toLowerCase().includes(value.toLowerCase()) && value.length > 0,
+  );
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      setShowSuggestions(false);
+      inputRef.current?.blur();
+    }
+  }
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setShowSuggestions(true);
+        }}
+        onFocus={() => setShowSuggestions(true)}
+        onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+        onKeyDown={handleKeyDown}
+        placeholder="Group (optional)"
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs",
+          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+      />
+      {showSuggestions && filtered.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md border bg-popover p-1 shadow-md">
+          {filtered.map((group) => (
+            <li key={group}>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onChange(group);
+                  setShowSuggestions(false);
+                }}
+                className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+              >
+                {group}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/mobile-header.tsx
+++ b/src/components/mobile-header.tsx
@@ -1,5 +1,6 @@
 import { MobileSidebar } from "./mobile-sidebar";
 import { ThemeToggle } from "./theme-toggle";
+import type { NoteWithTags } from "@/app/actions/stocks";
 
 type Channel = {
   id: string;
@@ -11,10 +12,16 @@ type Channel = {
   updatedAt: Date;
 };
 
-export function MobileHeader({ channels }: { channels: Channel[] }) {
+export function MobileHeader({
+  channels,
+  notes,
+}: {
+  channels: Channel[];
+  notes: NoteWithTags[];
+}) {
   return (
     <header className="flex h-14 items-center border-b px-4 md:hidden">
-      <MobileSidebar channels={channels} />
+      <MobileSidebar channels={channels} notes={notes} />
       <h1 className="ml-3 flex-1 text-lg font-semibold">Thread</h1>
       <ThemeToggle />
     </header>

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +13,8 @@ import {
 } from "@/components/ui/sheet";
 import { ChannelList } from "./channel-list";
 import { CreateChannelDialog } from "./create-channel-dialog";
+import { NotesSidebarSection } from "./notes-sidebar-section";
+import type { NoteWithTags } from "@/app/actions/stocks";
 
 type Channel = {
   id: string;
@@ -25,8 +28,10 @@ type Channel = {
 
 export function MobileSidebar({
   channels,
+  notes,
 }: {
   channels: Channel[];
+  notes: NoteWithTags[];
 }) {
   const [open, setOpen] = useState(false);
 
@@ -51,6 +56,22 @@ export function MobileSidebar({
         </div>
         <nav className="px-2 pb-4">
           <ChannelList channels={channels} onNavigate={() => setOpen(false)} />
+        </nav>
+
+        <div className="flex items-center justify-between px-4 pt-2 pb-2">
+          <Link
+            href="/notes"
+            onClick={() => setOpen(false)}
+            className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+          >
+            Notes
+          </Link>
+        </div>
+        <nav className="px-2 pb-4">
+          <NotesSidebarSection
+            notes={notes}
+            onNavigate={() => setOpen(false)}
+          />
         </nav>
       </SheetContent>
     </Sheet>

--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { createNote, updateNote, deleteNote } from "@/app/actions/stocks";
+import type { NoteWithTags } from "@/app/actions/stocks";
+import { TagInput } from "./tag-input";
+import { GroupSelect } from "./group-select";
+import { Button } from "@/components/ui/button";
+
+interface NoteEditorProps {
+  note?: NoteWithTags;
+  groups: string[];
+  tagSuggestions: string[];
+}
+
+export function NoteEditor({ note, groups, tagSuggestions }: NoteEditorProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(note?.title ?? "");
+  const [content, setContent] = useState(note?.content ?? "");
+  const [group, setGroup] = useState(note?.group ?? "");
+  const [tags, setTags] = useState<string[]>(note?.tags ?? []);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (!title.trim() || saving) return;
+    setSaving(true);
+
+    const data = {
+      title,
+      content,
+      group: group || null,
+      tags,
+    };
+
+    if (note) {
+      await updateNote(note.id, data);
+    } else {
+      const result = await createNote(data);
+      if (result && "id" in result && result.id) {
+        router.push(`/notes/${result.id}`);
+        return;
+      }
+    }
+
+    setSaving(false);
+  }, [title, content, group, tags, note, saving, router]);
+
+  async function handleDelete() {
+    if (!note) return;
+    if (!confirm("Delete this note?")) return;
+    await deleteNote(note.id);
+    router.push("/notes");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4" onKeyDown={handleKeyDown}>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        className="w-full border-none bg-transparent text-2xl font-bold outline-none placeholder:text-muted-foreground"
+      />
+
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Group
+        </label>
+        <GroupSelect value={group} onChange={setGroup} groups={groups} />
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Tags
+        </label>
+        <TagInput tags={tags} onChange={setTags} suggestions={tagSuggestions} />
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Content
+        </label>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write your note in Markdown..."
+          rows={16}
+          className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button onClick={handleSave} disabled={!title.trim() || saving}>
+          {saving ? "Saving..." : note ? "Save" : "Create"}
+        </Button>
+        {note && (
+          <Button variant="destructive" onClick={handleDelete}>
+            Delete
+          </Button>
+        )}
+        <span className="text-xs text-muted-foreground">Cmd+Enter to save</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import type { NoteWithTags } from "@/app/actions/stocks";
+
+interface NoteListProps {
+  notes: NoteWithTags[];
+}
+
+function formatDate(date: Date) {
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function NoteItem({ note }: { note: NoteWithTags }) {
+  return (
+    <Link
+      href={`/notes/${note.id}`}
+      className="block rounded-md px-3 py-2 transition-colors hover:bg-accent"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="truncate font-medium">{note.title}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {formatDate(note.updatedAt)}
+        </span>
+      </div>
+      {note.tags.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {note.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+export function NoteList({ notes }: NoteListProps) {
+  const grouped = new Map<string, NoteWithTags[]>();
+  const ungrouped: NoteWithTags[] = [];
+
+  for (const note of notes) {
+    if (note.group) {
+      const list = grouped.get(note.group) ?? [];
+      list.push(note);
+      grouped.set(note.group, list);
+    } else {
+      ungrouped.push(note);
+    }
+  }
+
+  const sortedGroups = [...grouped.keys()].sort();
+
+  return (
+    <div className="space-y-6">
+      {sortedGroups.map((group) => (
+        <section key={group}>
+          <h3 className="mb-2 px-3 text-sm font-semibold text-muted-foreground">
+            {group}
+          </h3>
+          <div className="space-y-0.5">
+            {grouped.get(group)!.map((note) => (
+              <NoteItem key={note.id} note={note} />
+            ))}
+          </div>
+        </section>
+      ))}
+      {ungrouped.length > 0 && (
+        <section>
+          {sortedGroups.length > 0 && (
+            <h3 className="mb-2 px-3 text-sm font-semibold text-muted-foreground">
+              Ungrouped
+            </h3>
+          )}
+          <div className="space-y-0.5">
+            {ungrouped.map((note) => (
+              <NoteItem key={note.id} note={note} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/notes-sidebar-section.tsx
+++ b/src/components/notes-sidebar-section.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { NoteWithTags } from "@/app/actions/stocks";
+
+interface NotesSidebarSectionProps {
+  notes: NoteWithTags[];
+  onNavigate?: () => void;
+}
+
+export function NotesSidebarSection({
+  notes,
+  onNavigate,
+}: NotesSidebarSectionProps) {
+  const pathname = usePathname();
+
+  const grouped = new Map<string, NoteWithTags[]>();
+  const ungrouped: NoteWithTags[] = [];
+
+  for (const note of notes) {
+    if (note.group) {
+      const list = grouped.get(note.group) ?? [];
+      list.push(note);
+      grouped.set(note.group, list);
+    } else {
+      ungrouped.push(note);
+    }
+  }
+
+  const sortedGroups = [...grouped.keys()].sort();
+
+  if (notes.length === 0) {
+    return (
+      <div className="px-2 py-2 text-center text-xs text-muted-foreground">
+        No notes yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {sortedGroups.map((group) => (
+        <GroupSection
+          key={group}
+          group={group}
+          notes={grouped.get(group)!}
+          pathname={pathname}
+          onNavigate={onNavigate}
+        />
+      ))}
+      {ungrouped.map((note) => (
+        <NoteLink
+          key={note.id}
+          note={note}
+          isActive={pathname === `/notes/${note.id}`}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </div>
+  );
+}
+
+function GroupSection({
+  group,
+  notes,
+  pathname,
+  onNavigate,
+}: {
+  group: string;
+  notes: NoteWithTags[];
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+      >
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
+        />
+        <span className="truncate">{group}</span>
+        <span className="ml-auto text-[10px]">{notes.length}</span>
+      </button>
+      {open && (
+        <div className="ml-2">
+          {notes.map((note) => (
+            <NoteLink
+              key={note.id}
+              note={note}
+              isActive={pathname === `/notes/${note.id}`}
+              onNavigate={onNavigate}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NoteLink({
+  note,
+  isActive,
+  onNavigate,
+}: {
+  note: NoteWithTags;
+  isActive: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <Link
+      href={`/notes/${note.id}`}
+      onClick={onNavigate}
+      className={cn(
+        "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent",
+        isActive && "bg-accent font-medium",
+      )}
+    >
+      <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate">{note.title}</span>
+    </Link>
+  );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,6 +1,9 @@
+import Link from "next/link";
 import { ChannelList } from "./channel-list";
 import { CreateChannelDialog } from "./create-channel-dialog";
+import { NotesSidebarSection } from "./notes-sidebar-section";
 import { ThemeToggle } from "./theme-toggle";
+import type { NoteWithTags } from "@/app/actions/stocks";
 
 type Channel = {
   id: string;
@@ -12,7 +15,13 @@ type Channel = {
   updatedAt: Date;
 };
 
-export function Sidebar({ channels }: { channels: Channel[] }) {
+export function Sidebar({
+  channels,
+  notes,
+}: {
+  channels: Channel[];
+  notes: NoteWithTags[];
+}) {
   return (
     <aside className="hidden w-64 shrink-0 border-r bg-muted/30 md:flex md:flex-col">
       <div className="flex h-14 items-center justify-between border-b px-4">
@@ -28,6 +37,18 @@ export function Sidebar({ channels }: { channels: Channel[] }) {
         </div>
         <nav className="px-2">
           <ChannelList channels={channels} />
+        </nav>
+
+        <div className="flex items-center justify-between px-4 pt-6 pb-2">
+          <Link
+            href="/notes"
+            className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+          >
+            Notes
+          </Link>
+        </div>
+        <nav className="px-2">
+          <NotesSidebarSection notes={notes} />
         </nav>
       </div>
     </aside>

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  suggestions: string[];
+}
+
+export function TagInput({ tags, onChange, suggestions }: TagInputProps) {
+  const [input, setInput] = useState("");
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = suggestions.filter(
+    (s) =>
+      s.includes(input.toLowerCase()) && !tags.includes(s) && input.length > 0,
+  );
+
+  function addTag(value: string) {
+    const normalized = value.toLowerCase().trim();
+    if (!normalized || tags.includes(normalized)) return;
+    onChange([...tags, normalized]);
+    setInput("");
+    setShowSuggestions(false);
+  }
+
+  function removeTag(tag: string) {
+    onChange(tags.filter((t) => t !== tag));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (input.trim()) {
+        addTag(input);
+      }
+    }
+    if (e.key === "Backspace" && !input && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="rounded-sm hover:bg-secondary-foreground/20"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setShowSuggestions(true);
+          }}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add tag..."
+          className={cn(
+            "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs",
+            "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          )}
+        />
+        {showSuggestions && filtered.length > 0 && (
+          <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md border bg-popover p-1 shadow-md">
+            {filtered.map((suggestion) => (
+              <li key={suggestion}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => addTag(suggestion)}
+                  className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+                >
+                  {suggestion}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,7 +3,9 @@ import {
   uuid,
   text,
   integer,
+  boolean,
   timestamp,
+  unique,
   pgPolicy,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
@@ -84,6 +86,7 @@ export const posts = pgTable(
       .notNull()
       .references(() => channels.id, { onDelete: "cascade" }),
     content: text("content").notNull(),
+    isPromoted: boolean("is_promoted").notNull().default(false),
     authorId: uuid("author_id")
       .notNull()
       .references(() => profiles.id),
@@ -150,6 +153,79 @@ export const postReplies = pgTable(
     pgPolicy("post_replies_delete", {
       for: "delete",
       using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = ${table.authorId})`,
+    }),
+  ],
+).enableRLS();
+
+export const stocks = pgTable(
+  "stocks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    status: text("status").notNull().default("inbox"),
+    title: text("title").notNull(),
+    content: text("content").notNull(),
+    group: text("group"),
+    sourcePostIds: text("source_post_ids").notNull().default("[]"),
+    sourceChannelId: uuid("source_channel_id").references(() => channels.id, {
+      onDelete: "set null",
+    }),
+    authorId: uuid("author_id")
+      .notNull()
+      .references(() => profiles.id),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    pgPolicy("stocks_select", {
+      for: "select",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = ${table.authorId})`,
+    }),
+    pgPolicy("stocks_insert", {
+      for: "insert",
+      withCheck: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = ${table.authorId})`,
+    }),
+    pgPolicy("stocks_update", {
+      for: "update",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = ${table.authorId})`,
+    }),
+    pgPolicy("stocks_delete", {
+      for: "delete",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = ${table.authorId})`,
+    }),
+  ],
+).enableRLS();
+
+export const stockTags = pgTable(
+  "stock_tags",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    stockId: uuid("stock_id")
+      .notNull()
+      .references(() => stocks.id, { onDelete: "cascade" }),
+    tag: text("tag").notNull(),
+  },
+  (table) => [
+    unique("stock_tags_stock_id_tag_unique").on(table.stockId, table.tag),
+    pgPolicy("stock_tags_select", {
+      for: "select",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = ${table.stockId}))`,
+    }),
+    pgPolicy("stock_tags_insert", {
+      for: "insert",
+      withCheck: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = ${table.stockId}))`,
+    }),
+    pgPolicy("stock_tags_update", {
+      for: "update",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = ${table.stockId}))`,
+    }),
+    pgPolicy("stock_tags_delete", {
+      for: "delete",
+      using: sql`auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = ${table.stockId}))`,
     }),
   ],
 ).enableRLS();


### PR DESCRIPTION
## Summary
- stocks テーブル（inbox/note を status で統一管理）と stock_tags テーブルを追加（RLS ポリシー付き）
- posts テーブルに isPromoted カラムを追加（PR2 の昇格機能用、現時点では未使用）
- ノート CRUD Server Actions（作成・一覧・詳細・編集・削除）
- グループ/タグ管理（自動サジェスト、小文字正規化）
- ノート一覧ページ（/notes）、詳細ページ（/notes/[id]）、新規作成ページ（/notes/new）
- サイドバーに Notes セクション追加（グループ別折りたたみ）
- Next.js 16 Turbopack ビルドエラー修正

## Test plan
- [ ] /notes ページでノート一覧が表示されること
- [ ] /notes/new で新規ノートが作成できること
- [ ] /notes/[id] でノートの編集・削除ができること
- [ ] サイドバーに Notes セクションが表示されること
- [ ] 既存のチャンネル・投稿機能が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)