### PR TITLE
feat: add promotion workflow, inbox page, and move-to-note

### DIFF
--- a/src/app/(app)/inbox/page.tsx
+++ b/src/app/(app)/inbox/page.tsx
@@ -1,0 +1,19 @@
+import { Inbox } from "lucide-react";
+import { getInboxItems, getNotes } from "@/app/actions/stocks";
+import { InboxList } from "@/components/inbox-list";
+
+export default async function InboxPage() {
+  const [items, notes] = await Promise.all([getInboxItems(), getNotes("note")]);
+
+  return (
+    <div className="-m-6 flex h-[calc(100%+48px)] flex-col">
+      <div className="flex h-14 shrink-0 items-center gap-2 border-b px-6">
+        <Inbox className="h-5 w-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold">Inbox</h2>
+      </div>
+      <div className="flex-1 overflow-auto px-6 py-4">
+        <InboxList items={items} existingNotes={notes} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,5 @@
 import { getChannels } from "@/app/actions/channels";
-import { getNotes } from "@/app/actions/stocks";
+import { getNotes, getInboxCount } from "@/app/actions/stocks";
 import { Sidebar } from "@/components/sidebar";
 import { MobileHeader } from "@/components/mobile-header";
 import { SearchModal } from "@/components/search-modal";
@@ -9,17 +9,26 @@ export default async function AppLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const [channelList, noteList] = await Promise.all([
+  const [channelList, noteList, inboxCount] = await Promise.all([
     getChannels(),
     getNotes("note"),
+    getInboxCount(),
   ]);
 
   return (
     <>
       <div className="flex h-screen">
-        <Sidebar channels={channelList} notes={noteList} />
+        <Sidebar
+          channels={channelList}
+          notes={noteList}
+          inboxCount={inboxCount}
+        />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <MobileHeader channels={channelList} notes={noteList} />
+          <MobileHeader
+            channels={channelList}
+            notes={noteList}
+            inboxCount={inboxCount}
+          />
           <main className="flex-1 overflow-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/app/actions/stocks.ts
+++ b/src/app/actions/stocks.ts
@@ -3,9 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { stocks, stockTags } from "@/db/schema";
-import { eq, and, isNotNull, asc, desc, inArray } from "drizzle-orm";
+import { eq, and, isNotNull, asc, desc, inArray, sql } from "drizzle-orm";
 import { getAuthProfile } from "./auth";
 import { getCachedAuthProfile } from "@/lib/cached-auth";
+import { posts, postReplies } from "@/db/schema";
 
 export type NoteWithTags = {
   id: string;
@@ -203,4 +204,250 @@ export async function getTags(): Promise<string[]> {
     .orderBy(asc(stockTags.tag));
 
   return [...new Set(allTags.map((t) => t.tag))];
+}
+
+function formatTimestampForPromotion(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  const min = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d} ${h}:${min}`;
+}
+
+export async function promotePost(postId: string, title?: string) {
+  const profile = await getAuthProfile();
+
+  const [post] = await db.select().from(posts).where(eq(posts.id, postId));
+  if (!post) return { error: "Post not found" };
+  if (post.isPromoted) return { success: true, skipped: true };
+
+  const postTitle =
+    title?.trim() || post.content.slice(0, 30).replace(/\n/g, " ");
+
+  await db.insert(stocks).values({
+    status: "inbox",
+    title: postTitle,
+    content: post.content,
+    sourcePostIds: JSON.stringify([postId]),
+    sourceChannelId: post.channelId,
+    authorId: profile.id,
+  });
+
+  await db.update(posts).set({ isPromoted: true }).where(eq(posts.id, postId));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function promoteThread(postId: string, title?: string) {
+  const profile = await getAuthProfile();
+
+  const [parentPost] = await db
+    .select()
+    .from(posts)
+    .where(eq(posts.id, postId));
+  if (!parentPost) return { error: "Post not found" };
+
+  const replies = await db
+    .select()
+    .from(postReplies)
+    .where(eq(postReplies.postId, postId))
+    .orderBy(asc(postReplies.createdAt));
+
+  const allMessages = [parentPost, ...replies];
+
+  const contentParts = allMessages.map((msg) => {
+    const ts = formatTimestampForPromotion(msg.createdAt);
+    return `**[${ts}]**\n${msg.content}`;
+  });
+
+  const combinedContent = contentParts.join("\n\n---\n\n");
+  const allIds = allMessages.map((m) => m.id);
+  const postTitle =
+    title?.trim() || parentPost.content.slice(0, 30).replace(/\n/g, " ");
+
+  await db.insert(stocks).values({
+    status: "inbox",
+    title: postTitle,
+    content: combinedContent,
+    sourcePostIds: JSON.stringify(allIds),
+    sourceChannelId: parentPost.channelId,
+    authorId: profile.id,
+  });
+
+  await db
+    .update(posts)
+    .set({ isPromoted: true })
+    .where(eq(posts.id, parentPost.id));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function promoteMultiple(postIds: string[], title?: string) {
+  const profile = await getAuthProfile();
+
+  if (postIds.length === 0) return { error: "No posts selected" };
+
+  const selectedPosts = await db
+    .select()
+    .from(posts)
+    .where(inArray(posts.id, postIds))
+    .orderBy(asc(posts.createdAt));
+
+  const nonPromoted = selectedPosts.filter((p) => !p.isPromoted);
+  if (nonPromoted.length === 0) return { success: true, skipped: true };
+
+  const contentParts = nonPromoted.map((post) => {
+    const ts = formatTimestampForPromotion(post.createdAt);
+    return `**[${ts}]**\n${post.content}`;
+  });
+
+  const combinedContent = contentParts.join("\n\n---\n\n");
+  const postTitle =
+    title?.trim() || nonPromoted[0].content.slice(0, 30).replace(/\n/g, " ");
+
+  const channelId = nonPromoted[0].channelId;
+
+  await db.insert(stocks).values({
+    status: "inbox",
+    title: postTitle,
+    content: combinedContent,
+    sourcePostIds: JSON.stringify(nonPromoted.map((p) => p.id)),
+    sourceChannelId: channelId,
+    authorId: profile.id,
+  });
+
+  const idsToUpdate = nonPromoted.map((p) => p.id);
+  await db
+    .update(posts)
+    .set({ isPromoted: true })
+    .where(inArray(posts.id, idsToUpdate));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function getInboxItems(): Promise<NoteWithTags[]> {
+  const profile = await getCachedAuthProfile();
+
+  const items = await db
+    .select()
+    .from(stocks)
+    .where(and(eq(stocks.status, "inbox"), eq(stocks.authorId, profile.id)))
+    .orderBy(desc(stocks.createdAt));
+
+  return items.map((item) => ({ ...item, tags: [] }));
+}
+
+export async function getInboxCount(): Promise<number> {
+  const profile = await getCachedAuthProfile();
+
+  const [result] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(stocks)
+    .where(and(eq(stocks.status, "inbox"), eq(stocks.authorId, profile.id)));
+
+  return result?.count ?? 0;
+}
+
+export async function moveToNote(
+  stockId: string,
+  group?: string,
+  tags?: string[],
+) {
+  await getAuthProfile();
+
+  await db
+    .update(stocks)
+    .set({
+      status: "note",
+      group: group?.trim() || null,
+    })
+    .where(eq(stocks.id, stockId));
+
+  if (tags && tags.length > 0) {
+    const uniqueTags = [
+      ...new Set(tags.map((t) => t.toLowerCase().trim()).filter(Boolean)),
+    ];
+    if (uniqueTags.length > 0) {
+      await db.insert(stockTags).values(
+        uniqueTags.map((tag) => ({
+          stockId,
+          tag,
+        })),
+      );
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function mergeIntoNote(stockId: string, targetNoteId: string) {
+  await getAuthProfile();
+
+  const [inboxResults, targetResults] = await Promise.all([
+    db.select().from(stocks).where(eq(stocks.id, stockId)),
+    db.select().from(stocks).where(eq(stocks.id, targetNoteId)),
+  ]);
+  const inboxItem = inboxResults[0];
+  const targetNote = targetResults[0];
+  if (!inboxItem) return { error: "Inbox item not found" };
+  if (!targetNote) return { error: "Target note not found" };
+
+  const mergedContent = targetNote.content + "\n\n---\n\n" + inboxItem.content;
+
+  await db
+    .update(stocks)
+    .set({ content: mergedContent })
+    .where(eq(stocks.id, targetNoteId));
+
+  await db.delete(stocks).where(eq(stocks.id, stockId));
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function moveMultipleToNote(
+  ids: string[],
+  group?: string,
+  tags?: string[],
+) {
+  await getAuthProfile();
+
+  if (ids.length === 0) return { error: "No items selected" };
+
+  await db
+    .update(stocks)
+    .set({
+      status: "note",
+      group: group?.trim() || null,
+    })
+    .where(inArray(stocks.id, ids));
+
+  if (tags && tags.length > 0) {
+    const uniqueTags = [
+      ...new Set(tags.map((t) => t.toLowerCase().trim()).filter(Boolean)),
+    ];
+    if (uniqueTags.length > 0) {
+      const tagValues = ids.flatMap((id) =>
+        uniqueTags.map((tag) => ({ stockId: id, tag })),
+      );
+      await db.insert(stockTags).values(tagValues);
+    }
+  }
+
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function deleteStock(id: string) {
+  await getAuthProfile();
+
+  await db.delete(stocks).where(eq(stocks.id, id));
+
+  revalidatePath("/");
+  return { success: true };
 }

--- a/src/components/inbox-list.tsx
+++ b/src/components/inbox-list.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  Trash2,
+  ExternalLink,
+  FolderInput,
+  Inbox,
+  Square,
+  CheckSquare,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteStock, type NoteWithTags } from "@/app/actions/stocks";
+import { MoveToNoteModal } from "@/components/move-to-note-modal";
+
+interface InboxListProps {
+  items: NoteWithTags[];
+  existingNotes: NoteWithTags[];
+}
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function InboxList({ items, existingNotes }: InboxListProps) {
+  const router = useRouter();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [moveTarget, setMoveTarget] = useState<{
+    ids: string[];
+  } | null>(null);
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+  const [isPending, startTransition] = useTransition();
+
+  const selectionMode = selectedIds.size > 0;
+
+  const handleToggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleDelete = (id: string) => {
+    setDeletingIds((prev) => new Set(prev).add(id));
+    startTransition(async () => {
+      await deleteStock(id);
+      router.refresh();
+    });
+  };
+
+  const handleMoveToNote = (ids: string[]) => {
+    setMoveTarget({ ids });
+  };
+
+  const handleMoveComplete = () => {
+    setMoveTarget(null);
+    setSelectedIds(new Set());
+    router.refresh();
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+        <Inbox className="h-12 w-12" />
+        <p className="text-sm">Your inbox is empty.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {selectionMode && (
+        <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-4 py-2">
+          <span className="text-sm font-medium">
+            {selectedIds.size} selected
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSelectedIds(new Set())}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => handleMoveToNote([...selectedIds])}
+            >
+              <FolderInput className="mr-1 h-3 w-3" />
+              Move to Note
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className={`group rounded-lg border p-4 transition-colors hover:bg-muted/50 ${selectedIds.has(item.id) ? "border-primary/50 bg-primary/5" : ""}`}
+        >
+          <div className="flex items-start gap-3">
+            <button
+              onClick={() => handleToggleSelect(item.id)}
+              className="mt-1 shrink-0"
+            >
+              {selectedIds.has(item.id) ? (
+                <CheckSquare className="h-4 w-4 text-primary" />
+              ) : (
+                <Square className="h-4 w-4 text-muted-foreground" />
+              )}
+            </button>
+
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <h3 className="truncate font-medium">{item.title}</h3>
+                {item.sourceChannelId && (
+                  <Link
+                    href={`/channels/${item.sourceChannelId}`}
+                    className="shrink-0"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+                  </Link>
+                )}
+              </div>
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                {item.content}
+              </p>
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {formatDate(item.createdAt)}
+              </span>
+            </div>
+
+            <div className="flex shrink-0 gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={() => handleMoveToNote([item.id])}
+                title="Move to note"
+              >
+                <FolderInput className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-destructive hover:text-destructive"
+                onClick={() => handleDelete(item.id)}
+                disabled={deletingIds.has(item.id) || isPending}
+                title="Delete"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {moveTarget && (
+        <MoveToNoteModal
+          open={!!moveTarget}
+          onOpenChange={(open) => {
+            if (!open) setMoveTarget(null);
+          }}
+          stockIds={moveTarget.ids}
+          existingNotes={existingNotes}
+          onComplete={handleMoveComplete}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/mobile-header.tsx
+++ b/src/components/mobile-header.tsx
@@ -15,13 +15,19 @@ type Channel = {
 export function MobileHeader({
   channels,
   notes,
+  inboxCount,
 }: {
   channels: Channel[];
   notes: NoteWithTags[];
+  inboxCount?: number;
 }) {
   return (
     <header className="flex h-14 items-center border-b px-4 md:hidden">
-      <MobileSidebar channels={channels} notes={notes} />
+      <MobileSidebar
+        channels={channels}
+        notes={notes}
+        inboxCount={inboxCount}
+      />
       <h1 className="ml-3 flex-1 text-lg font-semibold">Thread</h1>
       <ThemeToggle />
     </header>

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, Inbox } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -29,9 +29,11 @@ type Channel = {
 export function MobileSidebar({
   channels,
   notes,
+  inboxCount,
 }: {
   channels: Channel[];
   notes: NoteWithTags[];
+  inboxCount?: number;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -57,6 +59,22 @@ export function MobileSidebar({
         <nav className="px-2 pb-4">
           <ChannelList channels={channels} onNavigate={() => setOpen(false)} />
         </nav>
+
+        <div className="px-2 pb-2">
+          <Link
+            href="/inbox"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+          >
+            <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span>Inbox</span>
+            {inboxCount !== undefined && inboxCount > 0 && (
+              <span className="ml-auto rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary-foreground">
+                {inboxCount}
+              </span>
+            )}
+          </Link>
+        </div>
 
         <div className="flex items-center justify-between px-4 pt-2 pb-2">
           <Link

--- a/src/components/move-to-note-modal.tsx
+++ b/src/components/move-to-note-modal.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useTransition } from "react";
+import { FileText, Plus } from "lucide-react";
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import {
+  moveToNote,
+  moveMultipleToNote,
+  mergeIntoNote,
+} from "@/app/actions/stocks";
+import type { NoteWithTags } from "@/app/actions/stocks";
+
+interface MoveToNoteModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stockIds: string[];
+  existingNotes: NoteWithTags[];
+  onComplete: () => void;
+}
+
+export function MoveToNoteModal({
+  open,
+  onOpenChange,
+  stockIds,
+  existingNotes,
+  onComplete,
+}: MoveToNoteModalProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const isSingle = stockIds.length === 1;
+
+  const handleSaveAsNewNote = () => {
+    startTransition(async () => {
+      if (isSingle) {
+        await moveToNote(stockIds[0]);
+      } else {
+        await moveMultipleToNote(stockIds);
+      }
+      onComplete();
+    });
+  };
+
+  const handleMergeIntoNote = (targetNoteId: string) => {
+    if (!isSingle) return;
+    startTransition(async () => {
+      await mergeIntoNote(stockIds[0], targetNoteId);
+      onComplete();
+    });
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Move to Note"
+      description="Save as a new note or merge into an existing note."
+    >
+      <CommandInput
+        placeholder="Search notes..."
+        disabled={isPending}
+      />
+      <CommandList>
+        <CommandEmpty>No notes found.</CommandEmpty>
+        <CommandGroup heading="Actions">
+          <CommandItem onSelect={handleSaveAsNewNote} disabled={isPending}>
+            <Plus className="mr-2 h-4 w-4" />
+            Save as new note
+          </CommandItem>
+        </CommandGroup>
+        {isSingle && existingNotes.length > 0 && (
+          <CommandGroup heading="Merge into existing note">
+            {existingNotes.map((note) => (
+              <CommandItem
+                key={note.id}
+                onSelect={() => handleMergeIntoNote(note.id)}
+                disabled={isPending}
+              >
+                <FileText className="mr-2 h-4 w-4" />
+                <div className="min-w-0 flex-1">
+                  <span className="truncate">{note.title}</span>
+                  {note.group && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {note.group}
+                    </span>
+                  )}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { memo, useEffect, useRef, useState } from "react";
-import { Pencil, Trash2, Check, X, MessageSquare } from "lucide-react";
+import {
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  MessageSquare,
+  Archive,
+  Square,
+  CheckSquare,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
@@ -12,6 +21,7 @@ type Post = {
   channelId: string;
   content: string;
   authorId: string;
+  isPromoted?: boolean;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -30,11 +40,19 @@ export const PostItem = memo(function PostItem({
   threadReplyCount,
   highlight,
   onOpenThread,
+  onPromote,
+  isSelected,
+  onToggleSelect,
+  selectionMode,
 }: {
   post: Post;
   threadReplyCount?: number;
   highlight?: boolean;
   onOpenThread: (postId: string) => void;
+  onPromote?: (postId: string) => void;
+  isSelected?: boolean;
+  onToggleSelect?: (postId: string) => void;
+  selectionMode?: boolean;
 }) {
   const highlightRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
@@ -81,17 +99,46 @@ export const PostItem = memo(function PostItem({
     }
   };
 
+  const handleClick = () => {
+    if (editing) return;
+    if (selectionMode && onToggleSelect) {
+      onToggleSelect(post.id);
+    } else {
+      onOpenThread(post.id);
+    }
+  };
+
   return (
     <div
       ref={highlightRef}
       id={`post-${post.id}`}
-      className={`group relative cursor-pointer border-b border-border/50 px-3 py-3 transition-colors duration-150 hover:bg-muted/50`}
-      onClick={!editing ? () => onOpenThread(post.id) : undefined}
+      className={`group relative cursor-pointer border-b border-border/50 px-3 py-3 transition-colors duration-150 hover:bg-muted/50 ${isSelected ? "bg-primary/5" : ""}`}
+      onClick={handleClick}
     >
       <div className="flex items-baseline gap-2">
+        {selectionMode && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSelect?.(post.id);
+            }}
+            className="relative top-0.5 shrink-0"
+          >
+            {isSelected ? (
+              <CheckSquare className="h-4 w-4 text-primary" />
+            ) : (
+              <Square className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
+        )}
         <span className="text-xs font-medium text-muted-foreground">
           {formatTimestamp(post.createdAt)}
         </span>
+        {post.isPromoted && (
+          <span className="inline-flex items-center gap-0.5 rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+            📌 Stocked
+          </span>
+        )}
         {isEdited && (
           <span className="text-xs italic text-muted-foreground">(edited)</span>
         )}
@@ -137,6 +184,30 @@ export const PostItem = memo(function PostItem({
           className="absolute -top-2 right-2 hidden gap-0.5 rounded-md border bg-background p-0.5 shadow-sm group-hover:flex"
           onClick={(e) => e.stopPropagation()}
         >
+          {!selectionMode && onToggleSelect && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => onToggleSelect(post.id)}
+              aria-label="Select post"
+              title="Select post"
+            >
+              <Square className="h-3 w-3" />
+            </Button>
+          )}
+          {!post.isPromoted && onPromote && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => onPromote(post.id)}
+              aria-label="Promote to inbox"
+              title="Promote to inbox"
+            >
+              <Archive className="h-3 w-3" />
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/post-list.tsx
+++ b/src/components/post-list.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { PostItem } from "@/components/post-item";
-import { MessageCircle } from "lucide-react";
+import { PromoteDialog } from "@/components/promote-dialog";
+import { MessageCircle, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type Post = {
   id: string;
   channelId: string;
   content: string;
   authorId: string;
+  isPromoted?: boolean;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -26,6 +29,14 @@ export function PostList({
   const bottomRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [promoteTarget, setPromoteTarget] = useState<{
+    type: "single" | "thread" | "multiple";
+    postIds: string[];
+    defaultTitle: string;
+  } | null>(null);
+
+  const selectionMode = selectedIds.size > 0;
 
   useEffect(() => {
     if (highlightPostId) {
@@ -47,6 +58,54 @@ export function PostList({
     [router, searchParams],
   );
 
+  const handleToggleSelect = useCallback((postId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(postId)) {
+        next.delete(postId);
+      } else {
+        next.add(postId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handlePromoteSingle = useCallback(
+    (postId: string) => {
+      const post = posts.find((p) => p.id === postId);
+      if (!post) return;
+      const defaultTitle = post.content.slice(0, 30).replace(/\n/g, " ");
+      setPromoteTarget({
+        type: "single",
+        postIds: [postId],
+        defaultTitle,
+      });
+    },
+    [posts],
+  );
+
+  const handleBulkPromote = useCallback(() => {
+    const ids = [...selectedIds];
+    const firstPost = posts.find((p) => ids.includes(p.id));
+    const defaultTitle = firstPost
+      ? firstPost.content.slice(0, 30).replace(/\n/g, " ")
+      : "";
+    setPromoteTarget({
+      type: "multiple",
+      postIds: ids,
+      defaultTitle,
+    });
+  }, [selectedIds, posts]);
+
+  const handlePromoteComplete = useCallback(() => {
+    setPromoteTarget(null);
+    setSelectedIds(new Set());
+  }, []);
+
+  const handleCancelSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
   if (posts.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground">
@@ -66,10 +125,44 @@ export function PostList({
             threadReplyCount={threadReplyCounts?.[post.id]}
             highlight={post.id === highlightPostId}
             onOpenThread={handleOpenThread}
+            onPromote={handlePromoteSingle}
+            isSelected={selectedIds.has(post.id)}
+            onToggleSelect={handleToggleSelect}
+            selectionMode={selectionMode}
           />
         ))}
         <div ref={bottomRef} />
       </div>
+
+      {selectionMode && (
+        <div className="sticky bottom-0 flex items-center justify-between border-t bg-background px-4 py-3 shadow-lg">
+          <span className="text-sm font-medium">
+            {selectedIds.size} selected
+          </span>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={handleCancelSelection}>
+              <X className="mr-1 h-3 w-3" />
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleBulkPromote}>
+              Promote {selectedIds.size} posts
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {promoteTarget && (
+        <PromoteDialog
+          open={!!promoteTarget}
+          onOpenChange={(open) => {
+            if (!open) setPromoteTarget(null);
+          }}
+          type={promoteTarget.type}
+          postIds={promoteTarget.postIds}
+          defaultTitle={promoteTarget.defaultTitle}
+          onComplete={handlePromoteComplete}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/promote-dialog.tsx
+++ b/src/components/promote-dialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  promotePost,
+  promoteThread,
+  promoteMultiple,
+} from "@/app/actions/stocks";
+
+interface PromoteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  type: "single" | "thread" | "multiple";
+  postIds: string[];
+  defaultTitle: string;
+  onComplete: () => void;
+}
+
+export function PromoteDialog({
+  open,
+  onOpenChange,
+  type,
+  postIds,
+  defaultTitle,
+  onComplete,
+}: PromoteDialogProps) {
+  const [title, setTitle] = useState(defaultTitle);
+  const [isPending, startTransition] = useTransition();
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      if (type === "single") {
+        await promotePost(postIds[0], title);
+      } else if (type === "thread") {
+        await promoteThread(postIds[0], title);
+      } else {
+        await promoteMultiple(postIds, title);
+      }
+      onComplete();
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !isPending) {
+      e.preventDefault();
+      handleConfirm();
+    }
+  };
+
+  const typeLabel =
+    type === "single"
+      ? "post"
+      : type === "thread"
+        ? "thread"
+        : `${postIds.length} posts`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Promote to Inbox</DialogTitle>
+          <DialogDescription>
+            Promote this {typeLabel} to your inbox for later review.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="promote-title">Title</Label>
+            <Input
+              id="promote-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter a title..."
+              autoFocus
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={isPending}>
+            {isPending ? "Promoting..." : "Promote"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Inbox } from "lucide-react";
 import { ChannelList } from "./channel-list";
 import { CreateChannelDialog } from "./create-channel-dialog";
 import { NotesSidebarSection } from "./notes-sidebar-section";
@@ -18,9 +19,11 @@ type Channel = {
 export function Sidebar({
   channels,
   notes,
+  inboxCount,
 }: {
   channels: Channel[];
   notes: NoteWithTags[];
+  inboxCount?: number;
 }) {
   return (
     <aside className="hidden w-64 shrink-0 border-r bg-muted/30 md:flex md:flex-col">
@@ -39,7 +42,22 @@ export function Sidebar({
           <ChannelList channels={channels} />
         </nav>
 
-        <div className="flex items-center justify-between px-4 pt-6 pb-2">
+        <div className="px-2 pt-4 pb-2">
+          <Link
+            href="/inbox"
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+          >
+            <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span>Inbox</span>
+            {inboxCount !== undefined && inboxCount > 0 && (
+              <span className="ml-auto rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary-foreground">
+                {inboxCount}
+              </span>
+            )}
+          </Link>
+        </div>
+
+        <div className="flex items-center justify-between px-4 pt-2 pb-2">
           <Link
             href="/notes"
             className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"


### PR DESCRIPTION
## Summary
- 投稿の昇格機能（単一/スレッド/複数選択）— フローからストックへのコピー
- 昇格済み投稿に 📌 バッジ表示、ホバーメニューに昇格ボタン追加
- インボックスページ（/inbox）— 昇格済みアイテムの一覧・削除・ノートへの移動
- ノートへの移動モーダル（新規ノート or 既存ノートにマージ）
- サイドバーに 📥 Inbox リンク（未処理件数バッジ付き）
- 複数投稿選択モード + 一括昇格バー

## Test plan
- [ ] 投稿のホバーメニューから昇格できること
- [ ] スレッドまとめて昇格できること
- [ ] /inbox ページにインボックスアイテムが表示されること
- [ ] インボックスからノートに移動できること
- [ ] 既存ノートにマージできること
- [ ] サイドバーに Inbox バッジが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)