### PR TITLE
feat: extend search to include notes (flow + stock cross-search)

### DIFF
--- a/src/app/actions/search.ts
+++ b/src/app/actions/search.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import { db } from "@/db";
-import { posts, postReplies, channels } from "@/db/schema";
+import { posts, postReplies, channels, stocks } from "@/db/schema";
 import { sql, eq } from "drizzle-orm";
 import { getAuthProfile } from "./auth";
+import { getCachedAuthProfile } from "@/lib/cached-auth";
 
 export type SearchResult = {
   id: string;
@@ -11,8 +12,9 @@ export type SearchResult = {
   channelId: string;
   channelName: string;
   createdAt: Date;
-  type: "post" | "reply";
+  type: "post" | "reply" | "note";
   similarity: number;
+  group?: string;
 };
 
 export async function searchPosts(query: string): Promise<SearchResult[]> {
@@ -46,8 +48,7 @@ export async function searchPosts(query: string): Promise<SearchResult[]> {
       channelId: channels.id,
       channelName: channels.name,
       createdAt: postReplies.createdAt,
-      similarity:
-        sql<number>`similarity(${postReplies.content}, ${trimmed})`,
+      similarity: sql<number>`similarity(${postReplies.content}, ${trimmed})`,
     })
     .from(postReplies)
     .innerJoin(posts, eq(postReplies.postId, posts.id))
@@ -66,4 +67,53 @@ export async function searchPosts(query: string): Promise<SearchResult[]> {
   results.sort((a, b) => b.similarity - a.similarity);
 
   return results.slice(0, 20);
+}
+
+export async function searchStocks(query: string): Promise<SearchResult[]> {
+  const profile = await getCachedAuthProfile();
+
+  if (!query?.trim()) return [];
+
+  const trimmed = query.trim();
+
+  const stockResults = await db
+    .select({
+      id: stocks.id,
+      title: stocks.title,
+      group: stocks.group,
+      createdAt: stocks.createdAt,
+      titleSimilarity: sql<number>`similarity(${stocks.title}, ${trimmed})`,
+      contentSimilarity: sql<number>`similarity(${stocks.content}, ${trimmed})`,
+    })
+    .from(stocks)
+    .where(
+      sql`${stocks.authorId} = ${profile.id} AND (${stocks.title} % ${trimmed} OR ${stocks.content} % ${trimmed})`,
+    )
+    .orderBy(
+      sql`GREATEST(similarity(${stocks.title}, ${trimmed}), similarity(${stocks.content}, ${trimmed})) DESC`,
+    )
+    .limit(20);
+
+  return stockResults.map((r) => ({
+    id: r.id,
+    content: r.title,
+    channelId: "",
+    channelName: "",
+    createdAt: r.createdAt,
+    type: "note" as const,
+    similarity: Math.max(r.titleSimilarity, r.contentSimilarity),
+    group: r.group ?? undefined,
+  }));
+}
+
+export async function searchAll(query: string): Promise<SearchResult[]> {
+  const [postResults, stockResults] = await Promise.all([
+    searchPosts(query),
+    searchStocks(query),
+  ]);
+
+  const merged = [...postResults, ...stockResults];
+  merged.sort((a, b) => b.similarity - a.similarity);
+
+  return merged.slice(0, 20);
 }

--- a/src/components/search-modal.tsx
+++ b/src/components/search-modal.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Hash, MessageSquare } from "lucide-react";
+import { BookOpen, Hash, MessageSquare } from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -11,7 +11,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { searchPosts, type SearchResult } from "@/app/actions/search";
+import { searchAll, type SearchResult } from "@/app/actions/search";
 
 function formatTimestamp(date: Date) {
   return date.toLocaleString(undefined, {
@@ -44,7 +44,7 @@ export function SearchModal() {
   const performSearch = useCallback(async (value: string) => {
     setLoading(true);
     try {
-      const data = await searchPosts(value);
+      const data = await searchAll(value);
       setResults(data);
     } catch {
       setResults([]);
@@ -75,7 +75,11 @@ export function SearchModal() {
     setOpen(false);
     setQuery("");
     setResults([]);
-    router.push(`/channels/${result.channelId}?highlight=${result.id}`);
+    if (result.type === "note") {
+      router.push(`/notes/${result.id}`);
+    } else {
+      router.push(`/channels/${result.channelId}?highlight=${result.id}`);
+    }
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -88,16 +92,17 @@ export function SearchModal() {
 
   const postResults = results.filter((r) => r.type === "post");
   const replyResults = results.filter((r) => r.type === "reply");
+  const noteResults = results.filter((r) => r.type === "note");
 
   return (
     <CommandDialog
       open={open}
       onOpenChange={handleOpenChange}
       title="Search"
-      description="Search posts and replies across all channels"
+      description="Search posts, replies, and notes"
     >
       <CommandInput
-        placeholder="Search posts and replies..."
+        placeholder="Search posts, replies, and notes..."
         value={query}
         onValueChange={handleSearch}
       />
@@ -153,9 +158,30 @@ export function SearchModal() {
           </CommandGroup>
         )}
 
+        {!loading && noteResults.length > 0 && (
+          <CommandGroup heading="Notes">
+            {noteResults.map((result) => (
+              <CommandItem
+                key={`note-${result.id}`}
+                value={`note-${result.id}`}
+                onSelect={() => handleSelect(result)}
+                className="flex flex-col items-start gap-1"
+              >
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <BookOpen className="h-3 w-3" />
+                  <span>{result.group || "Note"}</span>
+                  <span>·</span>
+                  <span>{formatTimestamp(result.createdAt)}</span>
+                </div>
+                <p className="line-clamp-2 text-sm">{result.content}</p>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
         {!loading && !query.trim() && (
           <div className="py-6 text-center text-sm text-muted-foreground">
-            Type to search posts and replies across all channels
+            Type to search posts, replies, and notes
           </div>
         )}
       </CommandList>


### PR DESCRIPTION
## Summary
- searchStocks 関数追加（pg_trgm similarity で title + content を検索）
- searchAll 関数で posts + stocks の検索結果を統合
- Cmd+K 検索モーダルに Notes グループ追加
- ノート検索結果クリックで /notes/[id] にジャンプ

## Test plan
- [ ] Cmd+K でノートのタイトル・内容が検索できること
- [ ] ノート検索結果をクリックで /notes/[id] に遷移すること
- [ ] 既存の投稿・返信の検索が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)