### PR TITLE
fix: match stock/note UI to prototype design

### DIFF
--- a/src/app/(app)/notes/page.tsx
+++ b/src/app/(app)/notes/page.tsx
@@ -6,7 +6,7 @@ export default async function NotesPage() {
   const notes = await getNotes("note");
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-3xl">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-2xl font-bold">Notes</h2>
         <Link

--- a/src/components/group-select.tsx
+++ b/src/components/group-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { cn } from "@/lib/utils";
+import { Folder, ChevronDown } from "lucide-react";
 
 interface GroupSelectProps {
   value: string;
@@ -10,58 +10,73 @@ interface GroupSelectProps {
 }
 
 export function GroupSelect({ value, onChange, groups }: GroupSelectProps) {
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = groups.filter(
-    (g) => g.toLowerCase().includes(value.toLowerCase()) && value.length > 0,
+  const filteredGroups = groups.filter((g) =>
+    g.toLowerCase().includes(inputValue.toLowerCase()),
   );
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      setShowSuggestions(false);
-      inputRef.current?.blur();
-    }
+  function selectGroup(group: string) {
+    onChange(group);
+    setInputValue(group);
+    setOpen(false);
   }
 
   return (
     <div className="relative">
-      <input
-        ref={inputRef}
-        type="text"
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value);
-          setShowSuggestions(true);
-        }}
-        onFocus={() => setShowSuggestions(true)}
-        onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
-        onKeyDown={handleKeyDown}
-        placeholder="Group (optional)"
-        className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs",
-          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        )}
-      />
-      {showSuggestions && filtered.length > 0 && (
-        <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md border bg-popover p-1 shadow-md">
-          {filtered.map((group) => (
-            <li key={group}>
-              <button
-                type="button"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => {
-                  onChange(group);
-                  setShowSuggestions(false);
-                }}
-                className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
-              >
-                {group}
-              </button>
-            </li>
+      {open ? (
+        <input
+          ref={inputRef}
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            onChange(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              setOpen(false);
+            }
+            if (e.key === "Escape") {
+              setOpen(false);
+              inputRef.current?.blur();
+            }
+          }}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          autoFocus
+          placeholder="Group name..."
+          className="h-6 w-28 bg-transparent text-xs outline-none placeholder:text-muted-foreground/50"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Folder className="h-3 w-3" />
+          {value || "No group"}
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </button>
+      )}
+
+      {open && filteredGroups.length > 0 && (
+        <div className="absolute left-0 top-full z-50 mt-1 min-w-[140px] overflow-hidden rounded-lg border bg-popover p-1 shadow-lg">
+          {filteredGroups.map((group) => (
+            <button
+              key={group}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectGroup(group);
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent"
+            >
+              <Folder className="h-3 w-3 text-muted-foreground" />
+              {group}
+            </button>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Menu, Inbox } from "lucide-react";
+import { Menu, Inbox, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -56,36 +56,45 @@ export function MobileSidebar({
           </span>
           <CreateChannelDialog />
         </div>
-        <nav className="px-2 pb-4">
+        <nav className="px-2">
           <ChannelList channels={channels} onNavigate={() => setOpen(false)} />
         </nav>
 
-        <div className="px-2 pb-2">
+        <div className="mx-4 my-2 border-t" />
+
+        <div className="flex items-center justify-between px-4 pb-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+            Stock
+          </span>
+          <Link
+            href="/notes/new"
+            onClick={() => setOpen(false)}
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+        <nav className="px-2 pb-4">
           <Link
             href="/inbox"
             onClick={() => setOpen(false)}
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+            className="mb-1 flex items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:bg-accent"
           >
-            <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            <span>Inbox</span>
+            <Inbox className="h-4 w-4" />
+            Inbox
             {inboxCount !== undefined && inboxCount > 0 && (
-              <span className="ml-auto rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary-foreground">
+              <span className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-medium text-primary-foreground">
                 {inboxCount}
               </span>
             )}
           </Link>
-        </div>
-
-        <div className="flex items-center justify-between px-4 pt-2 pb-2">
           <Link
             href="/notes"
             onClick={() => setOpen(false)}
-            className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+            className="mb-1 flex items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:bg-accent"
           >
-            Notes
+            All Notes
           </Link>
-        </div>
-        <nav className="px-2 pb-4">
           <NotesSidebarSection
             notes={notes}
             onNavigate={() => setOpen(false)}

--- a/src/components/move-to-note-modal.tsx
+++ b/src/components/move-to-note-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTransition } from "react";
-import { FileText, Plus } from "lucide-react";
+import { FilePlus, FileText } from "lucide-react";
 import {
   CommandDialog,
   CommandInput,
@@ -36,7 +36,7 @@ export function MoveToNoteModal({
 
   const isSingle = stockIds.length === 1;
 
-  const handleSaveAsNewNote = () => {
+  const handleCreateNew = () => {
     startTransition(async () => {
       if (isSingle) {
         await moveToNote(stockIds[0]);
@@ -47,10 +47,11 @@ export function MoveToNoteModal({
     });
   };
 
-  const handleMergeIntoNote = (targetNoteId: string) => {
-    if (!isSingle) return;
+  const handleMerge = (targetNoteId: string) => {
     startTransition(async () => {
-      await mergeIntoNote(stockIds[0], targetNoteId);
+      for (const stockId of stockIds) {
+        await mergeIntoNote(stockId, targetNoteId);
+      }
       onComplete();
     });
   };
@@ -60,33 +61,30 @@ export function MoveToNoteModal({
       open={open}
       onOpenChange={onOpenChange}
       title="Move to Note"
-      description="Save as a new note or merge into an existing note."
+      description="Save as a new note or merge into an existing one"
     >
-      <CommandInput
-        placeholder="Search notes..."
-        disabled={isPending}
-      />
+      <CommandInput placeholder="Search notes..." disabled={isPending} />
       <CommandList>
-        <CommandEmpty>No notes found.</CommandEmpty>
+        <CommandEmpty>No matching notes found.</CommandEmpty>
         <CommandGroup heading="Actions">
-          <CommandItem onSelect={handleSaveAsNewNote} disabled={isPending}>
-            <Plus className="mr-2 h-4 w-4" />
+          <CommandItem onSelect={handleCreateNew} disabled={isPending}>
+            <FilePlus className="mr-2 h-4 w-4" />
             Save as new note
           </CommandItem>
         </CommandGroup>
-        {isSingle && existingNotes.length > 0 && (
+        {existingNotes.length > 0 && (
           <CommandGroup heading="Merge into existing note">
             {existingNotes.map((note) => (
               <CommandItem
                 key={note.id}
-                onSelect={() => handleMergeIntoNote(note.id)}
+                onSelect={() => handleMerge(note.id)}
                 disabled={isPending}
               >
                 <FileText className="mr-2 h-4 w-4" />
-                <div className="min-w-0 flex-1">
-                  <span className="truncate">{note.title}</span>
+                <div className="flex flex-col">
+                  <span>{note.title}</span>
                   {note.group && (
-                    <span className="ml-2 text-xs text-muted-foreground">
+                    <span className="text-xs text-muted-foreground">
                       {note.group}
                     </span>
                   )}

--- a/src/components/note-editor.tsx
+++ b/src/components/note-editor.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useTransition, useRef, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createNote, updateNote, deleteNote } from "@/app/actions/stocks";
-import type { NoteWithTags } from "@/app/actions/stocks";
+import { Trash2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { TagInput } from "./tag-input";
 import { GroupSelect } from "./group-select";
-import { Button } from "@/components/ui/button";
+import { createNote, updateNote, deleteNote } from "@/app/actions/stocks";
+import type { NoteWithTags } from "@/app/actions/stocks";
 
 interface NoteEditorProps {
   note?: NoteWithTags;
@@ -16,97 +17,147 @@ interface NoteEditorProps {
 
 export function NoteEditor({ note, groups, tagSuggestions }: NoteEditorProps) {
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const [title, setTitle] = useState(note?.title ?? "");
   const [content, setContent] = useState(note?.content ?? "");
   const [group, setGroup] = useState(note?.group ?? "");
   const [tags, setTags] = useState<string[]>(note?.tags ?? []);
-  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
+    "idle",
+  );
+  const [noteId, setNoteId] = useState(note?.id);
+  const noteIdRef = useRef(note?.id);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-  const handleSave = useCallback(async () => {
-    if (!title.trim() || saving) return;
-    setSaving(true);
+  const save = useCallback((t: string, c: string, g: string, tg: string[]) => {
+    if (!t.trim()) return;
+    setSaveStatus("saving");
 
     const data = {
-      title,
-      content,
-      group: group || null,
-      tags,
+      title: t,
+      content: c,
+      group: g || null,
+      tags: tg,
     };
 
-    if (note) {
-      await updateNote(note.id, data);
-    } else {
-      const result = await createNote(data);
-      if (result && "id" in result && result.id) {
-        router.push(`/notes/${result.id}`);
-        return;
+    startTransition(async () => {
+      if (noteIdRef.current) {
+        await updateNote(noteIdRef.current, data);
+      } else {
+        const result = await createNote(data);
+        if (result && "id" in result && result.id) {
+          noteIdRef.current = result.id;
+          setNoteId(result.id);
+          window.history.replaceState(null, "", `/notes/${result.id}`);
+        }
       }
-    }
+      setSaveStatus("saved");
+      setTimeout(() => setSaveStatus("idle"), 1500);
+    });
+  }, []);
 
-    setSaving(false);
-  }, [title, content, group, tags, note, saving, router]);
+  const debouncedSave = useCallback(
+    (t: string, c: string, g: string, tg: string[]) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => save(t, c, g, tg), 800);
+    },
+    [save],
+  );
 
-  async function handleDelete() {
-    if (!note) return;
-    if (!confirm("Delete this note?")) return;
-    await deleteNote(note.id);
-    router.push("/notes");
+  function handleTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value;
+    setTitle(v);
+    debouncedSave(v, content, group, tags);
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-      e.preventDefault();
-      handleSave();
-    }
+  function handleContentChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const v = e.target.value;
+    setContent(v);
+    debouncedSave(title, v, group, tags);
+  }
+
+  function handleGroupChange(v: string) {
+    setGroup(v);
+    debouncedSave(title, content, v, tags);
+  }
+
+  function handleTagsChange(v: string[]) {
+    setTags(v);
+    save(title, content, group, v);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  function handleDelete() {
+    if (!noteIdRef.current) return;
+    if (!window.confirm("Delete this note?")) return;
+    const id = noteIdRef.current;
+
+    startTransition(async () => {
+      await deleteNote(id);
+      router.push("/notes");
+    });
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4" onKeyDown={handleKeyDown}>
-      <input
-        type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="Title"
-        className="w-full border-none bg-transparent text-2xl font-bold outline-none placeholder:text-muted-foreground"
-      />
-
-      <div className="space-y-1">
-        <label className="text-xs font-medium text-muted-foreground">
-          Group
-        </label>
-        <GroupSelect value={group} onChange={setGroup} groups={groups} />
+    <div className="mx-auto max-w-3xl">
+      <div className="flex items-start justify-between gap-4">
+        <input
+          value={title}
+          onChange={handleTitleChange}
+          placeholder="Untitled"
+          className="flex-1 bg-transparent text-3xl font-bold tracking-tight outline-none placeholder:text-muted-foreground/40"
+        />
+        <div className="flex shrink-0 items-center gap-1 pt-2">
+          {saveStatus === "saving" && (
+            <span className="text-xs text-muted-foreground">Saving...</span>
+          )}
+          {saveStatus === "saved" && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Check className="h-3 w-3" />
+              Saved
+            </span>
+          )}
+          {noteId && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleDelete}
+              disabled={isPending}
+              aria-label="Delete"
+              className="h-7 w-7 text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
       </div>
 
-      <div className="space-y-1">
-        <label className="text-xs font-medium text-muted-foreground">
-          Tags
-        </label>
-        <TagInput tags={tags} onChange={setTags} suggestions={tagSuggestions} />
-      </div>
-
-      <div className="space-y-1">
-        <label className="text-xs font-medium text-muted-foreground">
-          Content
-        </label>
-        <textarea
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Write your note in Markdown..."
-          rows={16}
-          className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <GroupSelect
+          value={group}
+          onChange={handleGroupChange}
+          groups={groups}
+        />
+        <div className="h-4 w-px bg-border" />
+        <TagInput
+          tags={tags}
+          onChange={handleTagsChange}
+          suggestions={tagSuggestions}
         />
       </div>
 
-      <div className="flex items-center gap-2">
-        <Button onClick={handleSave} disabled={!title.trim() || saving}>
-          {saving ? "Saving..." : note ? "Save" : "Create"}
-        </Button>
-        {note && (
-          <Button variant="destructive" onClick={handleDelete}>
-            Delete
-          </Button>
-        )}
-        <span className="text-xs text-muted-foreground">Cmd+Enter to save</span>
+      <div className="mt-6">
+        <textarea
+          value={content}
+          onChange={handleContentChange}
+          placeholder="Write your note..."
+          className="prose prose-sm dark:prose-invert min-h-[50vh] w-full max-w-none resize-y bg-transparent px-0 py-2 outline-none placeholder:text-muted-foreground/40 focus:outline-none"
+        />
       </div>
     </div>
   );

--- a/src/components/note-list.tsx
+++ b/src/components/note-list.tsx
@@ -1,91 +1,94 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
+import { ChevronDown, ChevronRight, FileText } from "lucide-react";
 import type { NoteWithTags } from "@/app/actions/stocks";
 
 interface NoteListProps {
   notes: NoteWithTags[];
 }
 
-function formatDate(date: Date) {
-  return new Date(date).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function NoteItem({ note }: { note: NoteWithTags }) {
-  return (
-    <Link
-      href={`/notes/${note.id}`}
-      className="block rounded-md px-3 py-2 transition-colors hover:bg-accent"
-    >
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="truncate font-medium">{note.title}</span>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {formatDate(note.updatedAt)}
-        </span>
-      </div>
-      {note.tags.length > 0 && (
-        <div className="mt-1 flex flex-wrap gap-1">
-          {note.tags.map((tag) => (
-            <span
-              key={tag}
-              className="rounded-md bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-    </Link>
-  );
-}
-
 export function NoteList({ notes }: NoteListProps) {
-  const grouped = new Map<string, NoteWithTags[]>();
+  const grouped: Record<string, NoteWithTags[]> = {};
   const ungrouped: NoteWithTags[] = [];
 
   for (const note of notes) {
     if (note.group) {
-      const list = grouped.get(note.group) ?? [];
-      list.push(note);
-      grouped.set(note.group, list);
+      if (!grouped[note.group]) {
+        grouped[note.group] = [];
+      }
+      grouped[note.group].push(note);
     } else {
       ungrouped.push(note);
     }
   }
 
-  const sortedGroups = [...grouped.keys()].sort();
+  const groupNames = Object.keys(grouped).sort();
+
+  if (notes.length === 0) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">
+        <FileText className="mx-auto mb-3 h-12 w-12 opacity-50" />
+        <p className="text-lg font-medium">No notes yet</p>
+        <p className="mt-1 text-sm">Create your first note to get started.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-6">
-      {sortedGroups.map((group) => (
-        <section key={group}>
-          <h3 className="mb-2 px-3 text-sm font-semibold text-muted-foreground">
-            {group}
-          </h3>
-          <div className="space-y-0.5">
-            {grouped.get(group)!.map((note) => (
-              <NoteItem key={note.id} note={note} />
-            ))}
-          </div>
-        </section>
+    <div className="space-y-4">
+      {groupNames.map((group) => (
+        <GroupAccordion key={group} group={group} notes={grouped[group]} />
       ))}
       {ungrouped.length > 0 && (
-        <section>
-          {sortedGroups.length > 0 && (
-            <h3 className="mb-2 px-3 text-sm font-semibold text-muted-foreground">
-              Ungrouped
-            </h3>
-          )}
-          <div className="space-y-0.5">
-            {ungrouped.map((note) => (
-              <NoteItem key={note.id} note={note} />
-            ))}
-          </div>
-        </section>
+        <GroupAccordion group="Ungrouped" notes={ungrouped} />
+      )}
+    </div>
+  );
+}
+
+function GroupAccordion({
+  group,
+  notes,
+}: {
+  group: string;
+  notes: NoteWithTags[];
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+      >
+        {open ? (
+          <ChevronDown className="h-4 w-4" />
+        ) : (
+          <ChevronRight className="h-4 w-4" />
+        )}
+        {group}
+        <span className="ml-auto text-xs">{notes.length}</span>
+      </button>
+      {open && (
+        <ul className="ml-4 mt-1 space-y-0.5">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <Link
+                href={`/notes/${note.id}`}
+                className="flex items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent"
+              >
+                <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">{note.title}</span>
+                <span className="ml-auto text-xs text-muted-foreground">
+                  {new Date(note.updatedAt).toLocaleDateString()}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/components/notes-sidebar-section.tsx
+++ b/src/components/notes-sidebar-section.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ChevronRight, FileText } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { NoteWithTags } from "@/app/actions/stocks";
 
@@ -18,20 +18,21 @@ export function NotesSidebarSection({
 }: NotesSidebarSectionProps) {
   const pathname = usePathname();
 
-  const grouped = new Map<string, NoteWithTags[]>();
+  const grouped: Record<string, NoteWithTags[]> = {};
   const ungrouped: NoteWithTags[] = [];
 
   for (const note of notes) {
     if (note.group) {
-      const list = grouped.get(note.group) ?? [];
-      list.push(note);
-      grouped.set(note.group, list);
+      if (!grouped[note.group]) {
+        grouped[note.group] = [];
+      }
+      grouped[note.group].push(note);
     } else {
       ungrouped.push(note);
     }
   }
 
-  const sortedGroups = [...grouped.keys()].sort();
+  const groupNames = Object.keys(grouped).sort();
 
   if (notes.length === 0) {
     return (
@@ -42,12 +43,12 @@ export function NotesSidebarSection({
   }
 
   return (
-    <div className="space-y-1">
-      {sortedGroups.map((group) => (
-        <GroupSection
+    <div className="space-y-0.5">
+      {groupNames.map((group) => (
+        <SidebarGroup
           key={group}
           group={group}
-          notes={grouped.get(group)!}
+          notes={grouped[group]}
           pathname={pathname}
           onNavigate={onNavigate}
         />
@@ -64,7 +65,7 @@ export function NotesSidebarSection({
   );
 }
 
-function GroupSection({
+function SidebarGroup({
   group,
   notes,
   pathname,
@@ -82,25 +83,28 @@ function GroupSection({
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
+        className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
       >
-        <ChevronRight
-          className={cn("h-3 w-3 transition-transform", open && "rotate-90")}
-        />
+        {open ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        <BookOpen className="h-3 w-3" />
         <span className="truncate">{group}</span>
-        <span className="ml-auto text-[10px]">{notes.length}</span>
       </button>
       {open && (
-        <div className="ml-2">
+        <ul className="ml-3 space-y-0.5">
           {notes.map((note) => (
-            <NoteLink
-              key={note.id}
-              note={note}
-              isActive={pathname === `/notes/${note.id}`}
-              onNavigate={onNavigate}
-            />
+            <li key={note.id}>
+              <NoteLink
+                note={note}
+                isActive={pathname === `/notes/${note.id}`}
+                onNavigate={onNavigate}
+              />
+            </li>
           ))}
-        </div>
+        </ul>
       )}
     </div>
   );
@@ -120,12 +124,12 @@ function NoteLink({
       href={`/notes/${note.id}`}
       onClick={onNavigate}
       className={cn(
-        "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent",
+        "flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors hover:bg-accent",
         isActive && "bg-accent font-medium",
       )}
     >
       <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-      <span className="truncate">{note.title}</span>
+      <span className="truncate text-xs">{note.title}</span>
     </Link>
   );
 }

--- a/src/components/post-list.tsx
+++ b/src/components/post-list.tsx
@@ -31,9 +31,9 @@ export function PostList({
   const searchParams = useSearchParams();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [promoteTarget, setPromoteTarget] = useState<{
-    type: "single" | "thread" | "multiple";
-    postIds: string[];
-    defaultTitle: string;
+    mode:
+      | { type: "single"; postId: string; content: string; hasThread: boolean }
+      | { type: "multiple"; postIds: string[]; firstContent: string };
   } | null>(null);
 
   const selectionMode = selectedIds.size > 0;
@@ -74,26 +74,32 @@ export function PostList({
     (postId: string) => {
       const post = posts.find((p) => p.id === postId);
       if (!post) return;
-      const defaultTitle = post.content.slice(0, 30).replace(/\n/g, " ");
+      const content = post.content.slice(0, 30).replace(/\n/g, " ");
+      const hasThread = (threadReplyCounts?.[postId] ?? 0) > 0;
       setPromoteTarget({
-        type: "single",
-        postIds: [postId],
-        defaultTitle,
+        mode: {
+          type: "single",
+          postId,
+          content,
+          hasThread,
+        },
       });
     },
-    [posts],
+    [posts, threadReplyCounts],
   );
 
   const handleBulkPromote = useCallback(() => {
     const ids = [...selectedIds];
     const firstPost = posts.find((p) => ids.includes(p.id));
-    const defaultTitle = firstPost
+    const firstContent = firstPost
       ? firstPost.content.slice(0, 30).replace(/\n/g, " ")
       : "";
     setPromoteTarget({
-      type: "multiple",
-      postIds: ids,
-      defaultTitle,
+      mode: {
+        type: "multiple",
+        postIds: ids,
+        firstContent,
+      },
     });
   }, [selectedIds, posts]);
 
@@ -157,9 +163,7 @@ export function PostList({
           onOpenChange={(open) => {
             if (!open) setPromoteTarget(null);
           }}
-          type={promoteTarget.type}
-          postIds={promoteTarget.postIds}
-          defaultTitle={promoteTarget.defaultTitle}
+          mode={promoteTarget.mode}
           onComplete={handlePromoteComplete}
         />
       )}

--- a/src/components/promote-dialog.tsx
+++ b/src/components/promote-dialog.tsx
@@ -18,52 +18,56 @@ import {
   promoteMultiple,
 } from "@/app/actions/stocks";
 
+type PromoteMode =
+  | { type: "single"; postId: string; content: string; hasThread: boolean }
+  | { type: "multiple"; postIds: string[]; firstContent: string };
+
 interface PromoteDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  type: "single" | "thread" | "multiple";
-  postIds: string[];
-  defaultTitle: string;
+  mode: PromoteMode;
   onComplete: () => void;
 }
 
 export function PromoteDialog({
   open,
   onOpenChange,
-  type,
-  postIds,
-  defaultTitle,
+  mode,
   onComplete,
 }: PromoteDialogProps) {
+  const defaultTitle =
+    mode.type === "single"
+      ? mode.content.slice(0, 30)
+      : mode.firstContent.slice(0, 30);
   const [title, setTitle] = useState(defaultTitle);
+  const [includeThread, setIncludeThread] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const handleConfirm = () => {
+  const handlePromote = () => {
     startTransition(async () => {
-      if (type === "single") {
-        await promotePost(postIds[0], title);
-      } else if (type === "thread") {
-        await promoteThread(postIds[0], title);
+      if (mode.type === "single") {
+        if (includeThread && mode.hasThread) {
+          await promoteThread(mode.postId, title);
+        } else {
+          await promotePost(mode.postId, title);
+        }
       } else {
-        await promoteMultiple(postIds, title);
+        await promoteMultiple(mode.postIds, title);
       }
       onComplete();
+      onOpenChange(false);
     });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !isPending) {
       e.preventDefault();
-      handleConfirm();
+      handlePromote();
     }
   };
 
   const typeLabel =
-    type === "single"
-      ? "post"
-      : type === "thread"
-        ? "thread"
-        : `${postIds.length} posts`;
+    mode.type === "single" ? "post" : `${mode.postIds.length} posts`;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -71,7 +75,7 @@ export function PromoteDialog({
         <DialogHeader>
           <DialogTitle>Promote to Inbox</DialogTitle>
           <DialogDescription>
-            Promote this {typeLabel} to your inbox for later review.
+            Save this {typeLabel} to your inbox for later.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4 py-2">
@@ -86,6 +90,17 @@ export function PromoteDialog({
               autoFocus
             />
           </div>
+          {mode.type === "single" && mode.hasThread && (
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={includeThread}
+                onChange={(e) => setIncludeThread(e.target.checked)}
+                className="rounded"
+              />
+              Include thread replies
+            </label>
+          )}
         </div>
         <DialogFooter>
           <Button
@@ -95,7 +110,7 @@ export function PromoteDialog({
           >
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={isPending}>
+          <Button onClick={handlePromote} disabled={isPending || !title.trim()}>
             {isPending ? "Promoting..." : "Promote"}
           </Button>
         </DialogFooter>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Inbox } from "lucide-react";
+import { Inbox, Plus } from "lucide-react";
 import { ChannelList } from "./channel-list";
 import { CreateChannelDialog } from "./create-channel-dialog";
 import { NotesSidebarSection } from "./notes-sidebar-section";
@@ -42,30 +42,38 @@ export function Sidebar({
           <ChannelList channels={channels} />
         </nav>
 
-        <div className="px-2 pt-4 pb-2">
+        <div className="mx-4 my-2 border-t" />
+
+        <div className="flex items-center justify-between px-4 pb-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+            Stock
+          </span>
+          <Link
+            href="/notes/new"
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+        <nav className="px-2 pb-4">
           <Link
             href="/inbox"
-            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+            className="mb-1 flex items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:bg-accent"
           >
-            <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            <span>Inbox</span>
+            <Inbox className="h-4 w-4" />
+            Inbox
             {inboxCount !== undefined && inboxCount > 0 && (
-              <span className="ml-auto rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary-foreground">
+              <span className="ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-medium text-primary-foreground">
                 {inboxCount}
               </span>
             )}
           </Link>
-        </div>
-
-        <div className="flex items-center justify-between px-4 pt-2 pb-2">
           <Link
             href="/notes"
-            className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground"
+            className="mb-1 flex items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:bg-accent"
           >
-            Notes
+            All Notes
           </Link>
-        </div>
-        <nav className="px-2">
           <NotesSidebarSection notes={notes} />
         </nav>
       </div>

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { X, Hash, Plus } from "lucide-react";
 
 interface TagInputProps {
   tags: string[];
@@ -11,91 +10,116 @@ interface TagInputProps {
 }
 
 export function TagInput({ tags, onChange, suggestions }: TagInputProps) {
-  const [input, setInput] = useState("");
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = suggestions.filter(
+  const filteredSuggestions = suggestions.filter(
     (s) =>
-      s.includes(input.toLowerCase()) && !tags.includes(s) && input.length > 0,
+      s.toLowerCase().includes(inputValue.toLowerCase()) &&
+      !tags.includes(s.toLowerCase()),
   );
 
   function addTag(value: string) {
     const normalized = value.toLowerCase().trim();
-    if (!normalized || tags.includes(normalized)) return;
-    onChange([...tags, normalized]);
-    setInput("");
-    setShowSuggestions(false);
+    if (normalized && !tags.includes(normalized)) {
+      onChange([...tags, normalized]);
+    }
+    setInputValue("");
+    setOpen(false);
   }
 
   function removeTag(tag: string) {
     onChange(tags.filter((t) => t !== tag));
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && inputValue.trim()) {
       e.preventDefault();
-      if (input.trim()) {
-        addTag(input);
-      }
+      addTag(inputValue);
     }
-    if (e.key === "Backspace" && !input && tags.length > 0) {
+    if (e.key === "Backspace" && !inputValue && tags.length > 0) {
       removeTag(tags[tags.length - 1]);
+    }
+    if (e.key === "Escape") {
+      setOpen(false);
+      inputRef.current?.blur();
     }
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap gap-1.5">
-        {tags.map((tag) => (
-          <span
-            key={tag}
-            className="inline-flex items-center gap-1 rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+    <div className="relative flex flex-wrap items-center gap-1.5">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="group inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+        >
+          <Hash className="h-3 w-3 opacity-50" />
+          {tag}
+          <button
+            type="button"
+            onClick={() => removeTag(tag)}
+            className="ml-0.5 rounded-full opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
           >
-            {tag}
-            <button
-              type="button"
-              onClick={() => removeTag(tag)}
-              className="rounded-sm hover:bg-secondary-foreground/20"
-            >
-              <X className="h-3 w-3" />
-            </button>
-          </span>
-        ))}
-      </div>
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+
       <div className="relative">
-        <input
-          ref={inputRef}
-          type="text"
-          value={input}
-          onChange={(e) => {
-            setInput(e.target.value);
-            setShowSuggestions(true);
-          }}
-          onFocus={() => setShowSuggestions(true)}
-          onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
-          onKeyDown={handleKeyDown}
-          placeholder="Add tag..."
-          className={cn(
-            "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs",
-            "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-          )}
-        />
-        {showSuggestions && filtered.length > 0 && (
-          <ul className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md border bg-popover p-1 shadow-md">
-            {filtered.map((suggestion) => (
-              <li key={suggestion}>
+        {open ? (
+          <input
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={() => setTimeout(() => setOpen(false), 150)}
+            autoFocus
+            placeholder="Add tag..."
+            className="h-6 w-24 bg-transparent text-xs outline-none placeholder:text-muted-foreground/50"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="inline-flex items-center gap-1 rounded-full border border-dashed border-muted-foreground/30 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-muted-foreground/60 hover:text-foreground"
+          >
+            <Plus className="h-3 w-3" />
+            Tag
+          </button>
+        )}
+
+        {open && (inputValue || filteredSuggestions.length > 0) && (
+          <div className="absolute left-0 top-full z-50 mt-1 min-w-[160px] overflow-hidden rounded-lg border bg-popover p-1 shadow-lg">
+            {filteredSuggestions.length > 0 ? (
+              filteredSuggestions.slice(0, 8).map((suggestion) => (
                 <button
+                  key={suggestion}
                   type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => addTag(suggestion)}
-                  className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    addTag(suggestion);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent"
                 >
+                  <Hash className="h-3 w-3 text-muted-foreground" />
                   {suggestion}
                 </button>
-              </li>
-            ))}
-          </ul>
+              ))
+            ) : inputValue.trim() ? (
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  addTag(inputValue);
+                }}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent"
+              >
+                <Plus className="h-3 w-3 text-muted-foreground" />
+                Create &quot;{inputValue.trim().toLowerCase()}&quot;
+              </button>
+            ) : null}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
プロトタイプ（thread-prototype）の UI デザインに完全に合わせて Stock/Note 関連コンポーネントを書き換え

- **TagInput**: 丸ピル Badge + Hash アイコン + `+Tag` ダッシュボタン + ドロップダウンサジェスト
- **GroupSelect**: Folder アイコン + ChevronDown + インライン入力モード
- **NoteEditor**: `text-3xl` タイトル + auto-save (800ms debounce) + メタデータ行（Group | Tags）
- **NoteList**: GroupAccordion + FileText アイコン + 日付表示 + Ungrouped セクション
- **NotesSidebarSection**: BookOpen グループアイコン + `text-xs` ノートリンク
- **Sidebar**: "Stock" セクション（区切り線 + Inbox/All Notes リンク + Plus ボタン）
- **PromoteDialog**: "Include thread replies" チェックボックス追加
- **MoveToNoteModal**: FilePlus アイコン + 2セクション構成

## Test plan
- [ ] Notes ページの UI がプロトタイプと一致すること
- [ ] タグ入力が丸ピルで表示されること
- [ ] サイドバーに "Stock" セクションが表示されること
- [ ] 昇格ダイアログに "Include thread replies" が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)