### PR TITLE
fix: add design docs, migration SQL, and persist theme

### DIFF
--- a/.claude/works/DEEP-PLAN.md
+++ b/.claude/works/DEEP-PLAN.md
@@ -1,0 +1,248 @@
+# Deep Plan: Stock + Note 機能
+
+> Updated at: 2026-03-17 23:55
+> Source: PLAN.md (Updated at: 2026-03-17 23:45)
+
+## How to Use
+
+- `[RESOLVED]` — 既存コードから判断済み。参考パターンを記載
+- `[DECISION NEEDED]` — あなたの判断が必要。placeholder を埋めてください
+- `[INFERRED]` — 既存パターンから推測。確認推奨
+
+---
+
+## PR 1/3: Schema + Notes
+
+### Step 1: スキーマ定義
+
+#### Processing Order
+
+**PO-1.1: stocks と stockTags の作成順序** `[RESOLVED]`
+
+> 制約: stockTags.stockId が stocks.id を参照する FK 制約
+
+```
+1. stocks テーブル定義 — 先に作成（FK 参照元）
+2. stockTags テーブル定義 — stocks.id を参照
+3. posts に isPromoted カラム追加
+```
+
+参考 (`src/db/schema.ts:79-116`): posts → postReplies の順序と同じパターン
+
+#### Domain Knowledge
+
+**DK-1.1: stockTags の UNIQUE 制約の Drizzle 定義方法** `[RESOLVED]`
+
+> 状況: `UNIQUE(stock_id, tag)` を Drizzle で定義する方法
+
+```typescript
+import { unique } from "drizzle-orm/pg-core";
+// テーブル定義の第3引数で:
+(table) => [
+  unique().on(table.stockId, table.tag),
+  // ... RLS ポリシー
+]
+```
+
+参考: Drizzle ORM ドキュメントの composite unique constraint パターン
+
+---
+
+### Step 3: stocks.ts CRUD
+
+#### Branching Decisions
+
+**BD-1.1: createNote のバリデーション — タイトル必須か** `[RESOLVED]`
+
+> 状況: ノート作成時にタイトルが空の場合のハンドリング
+
+既存パターン（`createChannel` の name バリデーション）に準拠:
+```typescript
+if (!title?.trim()) {
+  return { error: "Title is required" };
+}
+```
+
+参考 (`src/app/actions/channels.ts:37-39`): `if (!name?.trim()) return { error: "Channel name is required" };`
+
+**BD-1.2: deleteNote 時の stockTags の削除** `[RESOLVED]`
+
+> 制約: stockTags は `ON DELETE CASCADE` で定義するため、stocks 削除時に自動削除
+
+参考 (`src/db/schema.ts:124`): postReplies の `onDelete: "cascade"` と同じパターン
+
+#### Domain Knowledge
+
+**DK-1.2: グループなし（未分類）ノートの表示ラベル** `[DECISION NEEDED]` <!-- DECISION NEEDED -->
+
+> 状況: `group` が NULL のノートをどう表示するか
+
+選択肢:
+- **A:** 「未分類」ラベルの下にまとめる ← First suggestion
+- **B:** グループ見出しなしでフラットに表示
+- **C:** 「未分類」グループに自動割り当て（DB 上も）
+
+> **決定:** __________
+> **理由:** __________
+
+---
+
+### Step 4-5: tag-input / group-select コンポーネント
+
+#### Branching Decisions
+
+**BD-1.3: タグ入力の UI パターン** `[INFERRED]`
+
+> 状況: shadcn/ui に Select/Dropdown/Popover コンポーネントが未インストール。タグ入力のサジェスト UI をどう実装するか
+
+推測:
+- Input フィールド + フォーカス時にサジェストリストを表示するカスタム UI
+- cmdk (CommandDialog) を流用してポップオーバー的に使う方法もあるが、インラインでは重い
+- 最もシンプルな方法: Input + 条件付き `<ul>` ドロップダウン（CSS absolute positioning）
+
+参考 (`src/components/search-modal.tsx`): CommandDialog + CommandInput + CommandList の既存パターン。ただし full-screen modal のみ
+
+**BD-1.4: グループ選択の UI パターン** `[INFERRED]`
+
+> 状況: 既存グループのサジェスト + 新規グループ入力を1つの UI で提供
+
+推測:
+- Input フィールド + 入力時に既存グループをフィルタリング表示
+- Enter で確定（既存マッチ or 新規作成）
+- tag-input と同様の CSS ドロップダウンパターン
+
+---
+
+### Step 10-11: サイドバー Notes セクション
+
+#### Domain Knowledge
+
+**DK-1.3: サイドバーのノート表示量の制限** `[DECISION NEEDED]` <!-- DECISION NEEDED -->
+
+> 状況: ノートが大量にある場合、サイドバーにすべて表示すると見づらくなる
+
+選択肢:
+- **A:** グループ名のみ表示し、クリックで `/notes?group=xxx` に遷移 ← First suggestion
+- **B:** グループ別に折りたたみ可能なアコーディオンで全ノート表示
+- **C:** 最新 N 件のみ表示 + 「すべて見る」リンク
+
+> **決定:** __________
+> **理由:** __________
+
+---
+
+## PR 2/3: Promotion + Inbox
+
+### Step 3-4: post-item / post-list の変更
+
+#### Branching Decisions
+
+**BD-2.1: 選択モードの開始/終了方法** `[DECISION NEEDED]` <!-- DECISION NEEDED -->
+
+> 状況: 複数投稿を選択して一括昇格する際の UX
+
+選択肢:
+- **A:** 長押し or チェックボックスアイコンボタンで選択モードに入り、選択後に「N件を昇格」バー表示 ← First suggestion
+- **B:** Shift+Click で範囲選択（Slack 的）
+- **C:** 各投稿のホバーメニューに「選択」ボタンを追加、1つ選ぶと自動で選択モードに入る
+
+> **決定:** __________
+> **理由:** __________
+
+**BD-2.2: 既に昇格済みの投稿への対応** `[RESOLVED]`
+
+> 状況: is_promoted = true の投稿に対して昇格ボタンを表示するか
+
+既存パターンから: 昇格ボタンは非表示にし、📌 バッジのみ表示。Server Action 側でも `is_promoted` チェックしてスキップ（二重防止）
+
+#### Domain Knowledge
+
+**DK-2.1: スレッド昇格時の返信取得範囲** `[RESOLVED]`
+
+> 状況: promoteThread で対象になる返信の範囲
+
+```
+1. 親投稿（posts テーブル）を取得
+2. その postId に紐づく全 postReplies を取得
+3. 時系列順に結合
+```
+
+参考 (`src/components/thread-panel.tsx:244-247`): `Promise.all([getPost(postId), getReplies(postId)])` パターンと同じ
+
+---
+
+### Step 7: move-to-note-modal
+
+#### Branching Decisions
+
+**BD-2.3: インボックスからノートへの移動 UI フロー** `[RESOLVED]`
+
+> 状況: 「ノートに移動」ボタンを押した後の遷移
+
+既存の CommandDialog パターンを再利用:
+```
+1. ボタンクリック → CommandDialog オープン
+2. 「新規ノートとして保存」選択 → moveToNote (UPDATE status='note') → Dialog 閉じる
+3. 既存ノート検索 → 選択 → mergeIntoNote → Dialog 閉じる
+```
+
+参考 (`src/components/search-modal.tsx`): CommandDialog + 検索 + 結果選択 → 遷移のパターン
+
+---
+
+## PR 3/3: Search Extension
+
+### Step 1-2: 検索拡張
+
+#### Processing Order
+
+**PO-3.1: searchAll の統合方法** `[RESOLVED]`
+
+> 制約: 既存の searchPosts は posts + postReplies を個別クエリで取得してマージ
+
+```
+1. 既存の searchPosts をそのまま維持（後方互換）
+2. searchStocks を新規追加（stocks テーブル対象）
+3. searchAll = searchPosts の結果 + searchStocks の結果をマージ・ソート
+```
+
+参考 (`src/app/actions/search.ts:61-68`): 既存の merge + sort パターンをそのまま拡張
+
+#### Domain Knowledge
+
+**DK-3.1: ノート検索結果の表示情報** `[RESOLVED]`
+
+> 状況: ノートには channelId/channelName がないため、検索結果の表示を調整
+
+```
+- type: "note" の場合: 📚 アイコン + グループ名（or "Note"）+ タイムスタンプ
+- type: "post"/"reply" の場合: 既存通り # チャンネル名 + タイムスタンプ
+```
+
+参考 (`src/components/search-modal.tsx:123-128`): アイコン + メタ情報 + コンテンツの表示パターン
+
+---
+
+## Summary
+
+### Decision Matrix
+
+| ID | Category | PR | Step | Status | Summary |
+|----|----------|-----|------|--------|---------|
+| PO-1.1 | Order | 1 | 1 | RESOLVED | stocks → stockTags → posts.isPromoted の順 |
+| DK-1.1 | Domain | 1 | 1 | RESOLVED | UNIQUE 制約の Drizzle 定義方法 |
+| BD-1.1 | Branching | 1 | 3 | RESOLVED | createNote のタイトルバリデーション |
+| BD-1.2 | Branching | 1 | 3 | RESOLVED | deleteNote 時の CASCADE 自動削除 |
+| DK-1.2 | Domain | 1 | 3 | DECISION NEEDED | グループなしノートの表示ラベル |
+| BD-1.3 | Branching | 1 | 4 | INFERRED | タグ入力の UI パターン |
+| BD-1.4 | Branching | 1 | 5 | INFERRED | グループ選択の UI パターン |
+| DK-1.3 | Domain | 1 | 10 | DECISION NEEDED | サイドバーのノート表示量制限 |
+| BD-2.1 | Branching | 2 | 3 | DECISION NEEDED | 選択モードの開始/終了方法 |
+| BD-2.2 | Branching | 2 | 3 | RESOLVED | 昇格済み投稿のボタン非表示 |
+| DK-2.1 | Domain | 2 | - | RESOLVED | スレッド昇格の返信範囲 |
+| BD-2.3 | Branching | 2 | 7 | RESOLVED | ノートへの移動 UI フロー |
+| PO-3.1 | Order | 3 | 1 | RESOLVED | searchAll の統合方法 |
+| DK-3.1 | Domain | 3 | 2 | RESOLVED | ノート検索結果の表示 |
+
+### Statistics
+- Total: 14 / Resolved: 10 / Inferred: 2 / Decision needed: 3 (DK-1.2, DK-1.3, BD-2.1)

--- a/.claude/works/PHASE.md
+++ b/.claude/works/PHASE.md
@@ -1,0 +1,26 @@
+phase: "orchestrate-complete"
+pr_chain:
+  total: 3
+  completed:
+    - pr: 1
+      branch: "feat/stock-note/1-3-schema-and-notes"
+      worktree: "/Users/ta21cos/ghq/github.com/ta21cos/thread/.claude/worktrees/agent-abc0ed8c"
+      review_result: "APPROVED"
+    - pr: 2
+      branch: "feat/stock-note/2-3-promotion-inbox"
+      worktree: "/Users/ta21cos/ghq/github.com/ta21cos/thread/.claude/worktrees/agent-ae022cec"
+      review_result: "APPROVED"
+    - pr: 3
+      branch: "feat/stock-note/3-3-search-extension"
+      worktree: "/Users/ta21cos/ghq/github.com/ta21cos/thread/.claude/worktrees/agent-a818df95"
+      review_result: "APPROVED"
+  in_progress: []
+  failed: []
+  skipped: []
+  waves:
+    - prs: [1]
+      status: "complete"
+    - prs: [2]
+      status: "complete"
+    - prs: [3]
+      status: "complete"

--- a/.claude/works/PLAN.md
+++ b/.claude/works/PLAN.md
@@ -1,0 +1,189 @@
+# Plan: Stock + Note 機能（Flow×Stock PKM Phase 2）
+
+> Updated at: 2026-03-17 23:45
+
+## Goal
+
+既存のフロー（チャンネル + 投稿 + スレッド）に「昇格 → インボックス → ノート」のストック化パイプラインを追加する。
+書き捨ての投稿が知識として蓄積されるデータ導線を実現する。
+
+## Key Design Decisions
+
+### 昇格のセマンティクス: コピー（元投稿は残る）
+- 昇格は投稿のコンテンツを stocks テーブルに**コピー**する操作。元の投稿はフロー上にそのまま残る
+- 元投稿には `is_promoted = true` のフラグが立ち、📌 バッジで視覚的に表示
+- `source_post_ids` は JSON テキスト参照であり FK ではない。元投稿が削除されてもストックには影響しない
+
+### stockTags テーブルの設計: タグテーブル直接方式
+- 別途 `tags` マスターテーブルは作らない
+- `stock_tags` は `stock_id` + `tag`（テキスト）で構成される直接テーブル
+- `UNIQUE(stock_id, tag)` で同一ストック内の重複を防止
+- タグサジェストは `SELECT DISTINCT tag FROM stock_tags` で実現
+
+### promoteThread のコンテンツ統合
+- 親投稿 + 返信を `\n\n---\n\n` 区切りで結合して1つの stock コンテンツにする
+- 各メッセージの先頭にタイムスタンプを付与（`**[2026-03-17 10:30]**\n内容`）
+- 全メッセージの ID を `source_post_ids` に JSON 配列で保存
+
+### 検索モーダルの拡張方式: CommandGroup 追加
+- cmdk にはタブ機能がないため、新しい `CommandGroup heading="Notes"` を追加する方式で実装
+- SearchResult 型を `type: "post" | "reply" | "note"` に拡張。notes は channelId/channelName がないため、group フィールドで代替表示
+
+### マイグレーション戦略: drizzle-kit push
+- マイグレーションファイルは生成しない。`bunx drizzle-kit push` で直接 DB に反映
+- push 後に Supabase ダッシュボードで RLS ポリシーの適用を必ず確認
+
+## PR Chain
+
+> Total: 3 PRs
+> Schema: PR1 で全新規テーブル + ALTER TABLE を一括追加
+
+### Dependency Graph
+
+```
+Wave 1: [PR 1]        ← 依存なし
+Wave 2: [PR 2]        ← PR 1 完了後
+Wave 3: [PR 3]        ← PR 2 完了後
+```
+
+```mermaid
+graph LR
+  PR1[PR 1: Schema + Notes] --> PR2[PR 2: Promotion + Inbox]
+  PR2 --> PR3[PR 3: Search Extension]
+```
+
+> **直列:** 3 PR は順番にマージ。PR 2 は PR 1 の stocks テーブル + サイドバー変更に依存。PR 3 は PR 2 のサイドバー変更と競合するため直列
+
+### PR 1/3: Schema + Notes — スキーマ拡張 + ノート CRUD + サイドバー再構成
+
+- **Pattern:** Foundation First
+- **Branch:** feat/stock-note/1-3-schema-and-notes
+- **Base:** main
+- **Scope:** FR-1, FR-2, FR-3, FR-4, FR-5, FR-6, FR-7, FR-8
+- **Depends on:** (none)
+- **Releasable alone:** Yes — ノートの作成・閲覧・編集・削除が単独で機能する。is_promoted カラムは追加されるが未使用なので無害
+- **Files:**
+  - `src/db/schema.ts` — stocks, stockTags テーブル定義追加（RLS ポリシー含む）+ posts に isPromoted 追加
+  - `src/app/actions/stocks.ts` — ストック（ノート）CRUD Server Actions + グループ/タグ取得
+  - `src/app/(app)/notes/page.tsx` — ノート一覧ページ（status='note' のみ、グループ別表示）
+  - `src/app/(app)/notes/[id]/page.tsx` — ノート詳細・編集ページ
+  - `src/components/note-list.tsx` — グループ別ノート一覧コンポーネント
+  - `src/components/note-editor.tsx` — Markdown textarea エディタ + タイトル + グループ + タグ
+  - `src/components/tag-input.tsx` — タグ入力（過去タグサジェスト、小文字正規化、Enter で追加）
+  - `src/components/group-select.tsx` — グループ選択（既存グループサジェスト + 新規入力）
+  - `src/components/sidebar.tsx` — 📚 Notes セクション追加（グループ別ツリー）
+  - `src/components/mobile-sidebar.tsx` — 同上
+  - `src/app/(app)/layout.tsx` — Notes 関連データの取得追加
+- **Steps:**
+  1. `src/db/schema.ts`: Drizzle スキーマに stocks, stockTags テーブル追加
+     - stocks: id(uuid), status(text), title(text), content(text), group(text nullable), sourcePostIds(text, JSON array), sourceChannelId(uuid, ref channels ON DELETE SET NULL), authorId(uuid, ref profiles), timestamps
+     - stockTags: id(uuid), stockId(uuid, ref stocks ON DELETE CASCADE), tag(text), UNIQUE(stockId, tag)
+     - RLS ポリシー: stocks は `auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = stocks.authorId)` パターン。stockTags は `auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = stock_tags.stock_id))` パターン
+     - posts テーブルに `isPromoted` (boolean, default false) カラム追加
+  2. `bunx drizzle-kit push` でスキーマを DB に反映。push 後に Supabase ダッシュボードで RLS ポリシー確認
+  3. `src/app/actions/stocks.ts`: ノート CRUD — createNote, getNotes, getNoteById, updateNote, deleteNote。グループ一覧（DISTINCT group）・タグ一覧（DISTINCT tag）取得
+  4. `src/components/tag-input.tsx`: タグ入力コンポーネント — 自由テキスト入力、過去タグのドロップダウンサジェスト、Enter で追加、小文字正規化、重複排除
+  5. `src/components/group-select.tsx`: グループ選択コンポーネント — 既存グループのドロップダウン、新規グループの自由入力
+  6. `src/components/note-editor.tsx`: ノート編集 — タイトル input、Markdown textarea（既存パターン）、グループ選択、タグ入力、保存/削除ボタン。新規パッケージ不要
+  7. `src/components/note-list.tsx`: グループ別アコーディオン表示、各ノートのタイトル + タグ + 更新日時。グループなしノートはフラット表示（グループ付きの後に並べる）
+  8. `src/app/(app)/notes/page.tsx`: ノート一覧 — getNotes (status='note') を呼び出し、note-list で表示。空状態対応。「新規ノート作成」ボタン
+  9. `src/app/(app)/notes/[id]/page.tsx`: ノート詳細 — getNoteById で取得、note-editor で編集
+  10. `src/components/sidebar.tsx`: Channels セクションの下に 📚 Notes セクション追加。グループ別折りたたみアコーディオン（件数表示）で全ノートタイトルをリンク表示
+  11. `src/components/mobile-sidebar.tsx`: 同様に Notes セクション追加
+  12. `src/app/(app)/layout.tsx`: getNotes を呼び出して Sidebar/MobileHeader に渡す
+
+#### Deviations (実績)
+- **file_added**: `src/components/notes-sidebar-section.tsx` — サイドバー Notes セクションを独立コンポーネントとして分離（sidebar.tsx の肥大化回避）
+- **file_added**: `src/app/(app)/notes/new/page.tsx` — 新規ノート作成ページを追加（ノート一覧の「新規作成」ボタンの遷移先）
+
+### PR 2/3: Promotion + Inbox — 昇格 + インボックス + ノートへ移動
+
+- **Pattern:** Vertical Slice
+- **Branch:** feat/stock-note/2-3-promotion-inbox
+- **Base:** feat/stock-note/1-3-schema-and-notes
+- **Scope:** FR-9, FR-10, FR-11, FR-12, FR-13, FR-14, FR-15, FR-16, FR-17, FR-18, FR-19, NFR-1
+- **Depends on:** PR 1
+- **Releasable alone:** Yes（PR 1 マージ済みの前提で）— 昇格・インボックス・ノート移動の全フローが機能する
+- **Files:**
+  - `src/app/actions/stocks.ts` — 昇格 + インボックス操作を追加
+  - `src/app/(app)/inbox/page.tsx` — インボックスページ
+  - `src/components/inbox-list.tsx` — アイテム一覧（複数選択可能）
+  - `src/components/move-to-note-modal.tsx` — ノートへ移動（CommandDialog ベース）
+  - `src/components/promote-dialog.tsx` — 昇格確認ダイアログ（タイトル入力）
+  - `src/components/post-item.tsx` — 📌バッジ + 昇格ボタン追加
+  - `src/components/post-list.tsx` — 選択モード状態管理 + 一括昇格バー
+  - `src/components/sidebar.tsx` — 📥 Inbox 追加（バッジ付き）
+  - `src/components/mobile-sidebar.tsx` — 同上
+  - `src/app/(app)/layout.tsx` — Inbox カウント取得追加
+  - `src/app/(app)/channels/[id]/page.tsx` — posts に isPromoted を含めて取得
+- **Steps:**
+  1. 昇格 Server Actions（stocks.ts に追加）:
+     - `promotePost(postId, title?)` — 投稿コンテンツを stocks にコピー（status='inbox'）、posts.is_promoted = true に更新。タイトル省略時は投稿冒頭30文字
+     - `promoteThread(postId, title?)` — 親投稿 + 返信を取得し、タイムスタンプ付きで `\n\n---\n\n` 結合してコピー。全 ID を source_post_ids に保存
+     - `promoteMultiple(postIds[], title?)` — 複数投稿を同様に結合してコピー
+     - 重複防止: is_promoted = true の投稿はスキップ（エラーではなく無視）
+  2. インボックス操作 Server Actions:
+     - `getInboxItems()` — WHERE status='inbox' ORDER BY created_at DESC
+     - `getInboxCount()` — COUNT WHERE status='inbox'（サイドバーバッジ用）
+     - `moveToNote(stockId, group?, tags?)` — UPDATE SET status='note', group=?
+     - `mergeIntoNote(stockId, targetNoteId)` — 既存ノートの content に `\n\n---\n\n` + inbox content を追記、元 inbox は削除
+     - `moveMultipleToNote(ids[], group?, tags?)` — 一括 UPDATE SET status='note'
+  3. `src/components/post-item.tsx`: ホバー時ツールバーに昇格ボタン（Archive アイコン）追加。is_promoted = true の投稿にタイムスタンプ横 📌 バッジ表示
+  4. `src/components/post-list.tsx`: ホバーメニューのチェックボックスで1件選択 → 選択モードに入る。selectedIds 管理。画面下部に一括昇格バー表示（「N件を昇格」+「キャンセル」）
+  5. `src/components/promote-dialog.tsx`: 昇格確認ダイアログ — タイトル入力（デフォルト: 投稿冒頭30文字）
+  6. `src/components/inbox-list.tsx`: インボックスアイテム一覧 — 複数選択チェックボックス、元チャンネルへのリンク（source_channel_id）、削除ボタン、ノートに移動ボタン。空状態対応
+  7. `src/components/move-to-note-modal.tsx`: CommandDialog ベース — 「新規ノートとして保存」選択肢 + 既存ノート検索・選択（mergeIntoNote）
+  8. `src/app/(app)/inbox/page.tsx`: インボックスページ — getInboxItems() で一覧表示
+  9. サイドバーに 📥 Inbox 追加（getInboxCount() でバッジ表示）
+  10. layout.tsx に Inbox カウント取得を追加
+  11. `src/app/(app)/channels/[id]/page.tsx`: getPosts 結果に isPromoted を含め、PostList に渡す
+
+### PR 3/3: Search Extension — ストック横断検索
+
+- **Pattern:** Vertical Slice
+- **Branch:** feat/stock-note/3-3-search-extension
+- **Base:** feat/stock-note/2-3-promotion-inbox
+- **Scope:** FR-20
+- **Depends on:** PR 2
+- **Releasable alone:** Yes — 検索の拡張のみ、なくても他機能は動く
+- **Files:**
+  - `src/app/actions/search.ts` — searchStocks 追加、結果を統合
+  - `src/components/search-modal.tsx` — Notes 用 CommandGroup 追加
+- **Steps:**
+  1. `src/app/actions/search.ts`:
+     - `searchStocks(query)` 追加 — stocks.title と stocks.content に対して `similarity()` で検索。結果に group, status を含む
+     - 既存の `searchPosts` を `searchAll(query)` にリネームまたはラップし、posts + stocks を統合して返す
+     - SearchResult 型を拡張: `type: "post" | "reply" | "note"` + `group?: string`（notes 用）。channelId/channelName は notes の場合は空文字列
+  2. `src/components/search-modal.tsx`:
+     - 新しい `CommandGroup heading="Notes"` を追加（タブ UI ではなく既存パターンの拡張）
+     - ノート結果: タイトル + グループ + タグ表示
+     - ノート結果クリックで `/notes/[id]` にジャンプ
+
+## Premortem
+
+| リスク | 影響度 | 発生確率 | 復旧方法 |
+|--------|--------|----------|----------|
+| `drizzle-kit push` で RLS ポリシー適用漏れ | High | Medium | push 後に Supabase ダッシュボードで `pg_policies` 確認。手動 SQL での補完手段を用意 |
+| stockTags の RLS サブクエリがパフォーマンス問題を起こす | Medium | Low | stockTags に authorId を直接追加してフラット化する代替案を用意 |
+| posts に isPromoted カラム追加で既存クエリに影響 | Medium | Low | デフォルト false で追加、既存コードは select() で全カラム取得するが boolean デフォルトで影響なし |
+| サイドバー変更で PR 間コンフリクト | Medium | Medium | PR を直列にし、各 PR で最新 base をリベース |
+| 昇格元投稿の削除後、stocks の source_post_ids が orphan 化 | Low | Medium | source_post_ids は参照情報のみ（FK なし）。UI 側でリンク切れを graceful に処理 |
+| グループ/タグの自由入力で表記ゆれ | Low | High | タグは小文字正規化で軽減。グループはサジェストで既存候補を提示 |
+
+## Deep Plan Decisions (Resolved)
+
+| ID | PR | Question | Decision |
+|----|----|----------|----------|
+| DK-1.2 | PR 1 | グループなしノートの表示 | フラット表示（グループ見出しなし、グループ付きノートの後に並べる） |
+| DK-1.3 | PR 1 | サイドバーのノート表示 | 全ノート折りたたみ（グループ別アコーディオン、件数表示） |
+| BD-2.1 | PR 2 | 複数投稿選択モード | ホバーメニューにチェックボックス追加。1つ選ぶと選択モードに入り、一括操作バー表示 |
+
+## Constraints
+
+- Server Actions のみ、API Routes 不使用
+- 新規パッケージ追加なし（既存の cmdk / shadcn/ui で実装）
+- Supabase Auth + profiles テーブルによる認証（既存パターン踏襲）
+- PostgreSQL の pg_trgm（similarity）を検索に使用
+- テストは書かない
+- drizzle-kit push ベースでスキーマ反映
+- 既存 Phase 1 機能（チャンネル、投稿、スレッド、検索）を壊さないこと（NFR-2）

--- a/.claude/works/RATIONALE.md
+++ b/.claude/works/RATIONALE.md
@@ -1,0 +1,40 @@
+# Rationale: Stock + Note 機能（Flow×Stock PKM Phase 2）
+
+> Updated at: 2026-03-17 23:55
+
+## Why — なぜこの実装を行うのか
+
+このアプリは「Slack のようなフロー管理」と「Obsidian のようなノート管理」を1つで完結させる個人 PKM ツール。Phase 1 でフロー（チャンネル + 投稿 + スレッド）が完成し、Phase 2 では書き捨ての投稿を知識として蓄積するストック化パイプラインを追加する。
+
+既存ツール（Slack, Notion, Obsidian, Memos）にはいずれも「チャンネルベースのフロー + 明示的な昇格 + インボックス + ノート」を一つで完結するものが存在しない。
+
+## Background — 実装の背景と意思決定
+
+- **プロトタイプからの移植**: `/Users/ta21cos/ghq/github.com/ta21cos/playground/thread-prototype` に SQLite ベースのプロトタイプが存在。本実装は PostgreSQL + Supabase Auth + RLS に適応させた版
+- **Flow × Stock の二層設計**: メッセージ（フロー）とストック（ノート）を2系統に分離。inbox と note は同一テーブル `stocks` で `status` カラムにより区別。ノート化は UPDATE 1発で完了
+- **昇格はコピー方式**: 元投稿はフローに残したまま、コンテンツを stocks にコピー。source_post_ids は FK ではなく JSON 参照で、元投稿の削除に影響されない
+- **グループなしノートはフラット表示**: ユーザー判断により、グループ見出しなしで直接表示。グループ付きノートの後に並べる
+- **サイドバーは全ノート折りたたみ**: グループ別アコーディオンで件数表示、展開して全ノートタイトルを表示
+- **選択モードはホバーメニュー起点**: ツールバーのチェックボックスで1件選択 → 選択モード突入 → 一括操作バー表示
+
+## Affected Tables
+
+| Table | Operation | Before | After |
+|-------|-----------|--------|-------|
+| stocks | NEW | — | 新規テーブル（inbox + note 統合、RLS 付き） |
+| stock_tags | NEW | — | 新規テーブル（多対多タグ、CASCADE 削除、RLS 付き） |
+| posts | WRITE | is_promoted なし | is_promoted (boolean, default false) カラム追加 |
+
+## Out-of-PR Actions
+
+- [ ] `bunx drizzle-kit push` 後に Supabase ダッシュボードで RLS ポリシーが正しく適用されているか確認
+- [ ] pg_trgm 拡張が stocks テーブルの検索でも機能することを確認
+
+## Depends On / Blocks
+
+- **PR 1 → PR 2 → PR 3**: 直列依存。各 PR は前の PR がマージされた前提で動作
+
+## Next Steps
+
+- Phase 2.5: タグ管理画面（リネーム・マージ）、インボックス放置通知
+- Phase 3: ノート成熟度ステータス、バックリンク `[[記法]]`、AI アシスト、SwiftUI ネイティブアプリ化

--- a/.claude/works/REQUIREMENTS.md
+++ b/.claude/works/REQUIREMENTS.md
@@ -1,0 +1,113 @@
+# Requirements: Stock + Note 機能（Flow×Stock PKM Phase 2）
+
+## Goal
+
+既存のフロー（チャンネル + 投稿 + スレッド）に「昇格 → インボックス → ノート」のストック化パイプラインを追加する。
+書き捨ての投稿が知識として蓄積されるデータ導線を実現する。
+
+## Constraints
+
+- 既存の技術スタック（Next.js 15 App Router + Drizzle ORM + PostgreSQL + Supabase Auth + shadcn/ui）
+- Server Actions のみ、API Routes 不使用
+- Drizzle Kit マイグレーション（`drizzle/` ディレクトリに SQL 生成）
+- 既存テーブルに RLS ポリシーあり — 新規テーブルにも同様に設定
+- 認証は Supabase Auth + profiles テーブル（authorId で所有者管理）
+- 既存の Phase 1 コードを壊さない
+- 新規パッケージ追加なし（既存の cmdk / shadcn/ui で実装）
+- 検索は PostgreSQL `pg_trgm`（`similarity()` / `%` 演算子）を使用（FTS5 は SQLite 固有）
+
+## Functional Requirements
+
+### ノート（ストック）
+- [ ] FR-1: ノート一覧ページ（`/notes`）— グループ別表示
+- [ ] FR-2: ノート詳細ページ（`/notes/[id]`）— Markdown エディタ（textarea ベース）
+- [ ] FR-3: ノートの作成（タイトル、内容、グループ、タグ）
+- [ ] FR-4: ノートの編集（タイトル、内容、グループ、タグ）
+- [ ] FR-5: ノートの削除
+- [ ] FR-6: グループ管理 — 1階層グループ、動的追加、既存グループサジェスト
+- [ ] FR-7: タグ管理 — 自由入力 + 過去タグサジェスト、複数タグ対応、小文字正規化
+- [ ] FR-8: サイドバーに「📚 Notes」セクション（グループ別ツリー表示）
+
+### 昇格（Promotion）
+- [ ] FR-9: 投稿1件を昇格（インボックスに送る）
+- [ ] FR-10: スレッド（親投稿 + 返信）をまとめて昇格
+- [ ] FR-11: 複数投稿を選択してまとめて昇格
+- [ ] FR-12: 昇格済み投稿に「📌 Stocked」バッジ表示
+- [ ] FR-13: 昇格時にタイトルを任意で入力可能（デフォルト: 投稿冒頭）
+
+### インボックス
+- [ ] FR-14: インボックスページ（`/inbox`）で昇格済みアイテム一覧表示
+- [ ] FR-15: サイドバーに「📥 Inbox」を表示（未処理件数バッジ付き）
+- [ ] FR-16: インボックスアイテムから元投稿へのジャンプリンク
+- [ ] FR-17: インボックスアイテムをノートに移動（既存ノートに追記 or 新規ノート作成）
+- [ ] FR-18: 複数アイテムを選択して一括移動
+- [ ] FR-19: インボックスアイテムの削除（不要なものを破棄）
+
+### 検索拡張
+- [ ] FR-20: グローバル検索（Cmd+K）をノートにも対応（フロー + ストック横断検索）
+
+## Data Model
+
+### 設計方針
+
+posts（フロー）と stocks（ストック）の2系統に分離。
+inbox と note は同一テーブル `stocks` で管理し、`status` ('inbox' | 'note') で区別する。
+理由: inbox は note の前段階であり、ノート化は UPDATE 1発で表現できる。
+
+### 新規テーブル
+
+```sql
+-- ストック（inbox + note 統合）
+stocks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  status TEXT NOT NULL DEFAULT 'inbox',      -- 'inbox' | 'note'
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  "group" TEXT,                               -- inbox 時は NULL、note 化で設定
+  source_post_ids TEXT NOT NULL DEFAULT '[]', -- JSON array of post IDs
+  source_channel_id UUID REFERENCES channels(id) ON DELETE SET NULL,
+  author_id UUID NOT NULL REFERENCES profiles(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+
+-- ストックのタグ（多対多）
+stock_tags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stock_id UUID NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  tag TEXT NOT NULL,
+  UNIQUE(stock_id, tag)
+)
+```
+
+### 既存テーブルの変更
+
+```sql
+-- posts テーブルに昇格フラグ追加
+ALTER TABLE posts ADD COLUMN is_promoted BOOLEAN NOT NULL DEFAULT false;
+```
+
+### RLS ポリシー
+
+stocks, stock_tags ともに既存テーブルと同様のパターンで RLS を設定:
+- SELECT/INSERT/UPDATE/DELETE すべて `auth.uid()` と `author_id` 経由の profiles 照合
+
+## Non-Functional Requirements
+
+- [ ] NFR-1: インボックスからノートへの移動は3クリック以内
+- [ ] NFR-2: 既存 Phase 1 機能が壊れないこと
+
+## Out of Scope
+
+- タグ管理画面（リネーム・マージ）— 将来
+- ノート成熟度ステータス（seed/budding/evergreen）— 将来
+- バックリンク `[[記法]]` — 将来
+- AIアシスト — 将来
+- インボックス放置通知 — 将来
+
+## Assumptions
+
+- グループ名は自由テキスト（事前定義なし）
+- タグは小文字に正規化して保存
+- ノートの Markdown エディタは textarea ベース
+- 昇格元の投稿 ID は JSON 配列で保持（PostgreSQL の TEXT カラム）

--- a/drizzle/0000_furry_toro.sql
+++ b/drizzle/0000_furry_toro.sql
@@ -1,0 +1,95 @@
+CREATE TABLE "channels" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"author_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "channels" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "post_replies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"content" text NOT NULL,
+	"author_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "post_replies" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"channel_id" uuid NOT NULL,
+	"content" text NOT NULL,
+	"is_promoted" boolean DEFAULT false NOT NULL,
+	"author_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "posts" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "profiles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"auth_user_id" uuid NOT NULL,
+	"display_name" text DEFAULT 'User' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "profiles_auth_user_id_unique" UNIQUE("auth_user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "profiles" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "stock_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"stock_id" uuid NOT NULL,
+	"tag" text NOT NULL,
+	CONSTRAINT "stock_tags_stock_id_tag_unique" UNIQUE("stock_id","tag")
+);
+--> statement-breakpoint
+ALTER TABLE "stock_tags" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "stocks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"status" text DEFAULT 'inbox' NOT NULL,
+	"title" text NOT NULL,
+	"content" text NOT NULL,
+	"group" text,
+	"source_post_ids" text DEFAULT '[]' NOT NULL,
+	"source_channel_id" uuid,
+	"author_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "stocks" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "channels" ADD CONSTRAINT "channels_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_replies" ADD CONSTRAINT "post_replies_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_replies" ADD CONSTRAINT "post_replies_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_channel_id_channels_id_fk" FOREIGN KEY ("channel_id") REFERENCES "public"."channels"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "posts" ADD CONSTRAINT "posts_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stock_tags" ADD CONSTRAINT "stock_tags_stock_id_stocks_id_fk" FOREIGN KEY ("stock_id") REFERENCES "public"."stocks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stocks" ADD CONSTRAINT "stocks_source_channel_id_channels_id_fk" FOREIGN KEY ("source_channel_id") REFERENCES "public"."channels"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stocks" ADD CONSTRAINT "stocks_author_id_profiles_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE POLICY "channels_select" ON "channels" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "channels"."author_id"));--> statement-breakpoint
+CREATE POLICY "channels_insert" ON "channels" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "channels"."author_id"));--> statement-breakpoint
+CREATE POLICY "channels_update" ON "channels" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "channels"."author_id"));--> statement-breakpoint
+CREATE POLICY "channels_delete" ON "channels" AS PERMISSIVE FOR DELETE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "channels"."author_id"));--> statement-breakpoint
+CREATE POLICY "post_replies_select" ON "post_replies" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "post_replies"."author_id"));--> statement-breakpoint
+CREATE POLICY "post_replies_insert" ON "post_replies" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "post_replies"."author_id"));--> statement-breakpoint
+CREATE POLICY "post_replies_update" ON "post_replies" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "post_replies"."author_id"));--> statement-breakpoint
+CREATE POLICY "post_replies_delete" ON "post_replies" AS PERMISSIVE FOR DELETE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "post_replies"."author_id"));--> statement-breakpoint
+CREATE POLICY "posts_select" ON "posts" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "posts"."author_id"));--> statement-breakpoint
+CREATE POLICY "posts_insert" ON "posts" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "posts"."author_id"));--> statement-breakpoint
+CREATE POLICY "posts_update" ON "posts" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "posts"."author_id"));--> statement-breakpoint
+CREATE POLICY "posts_delete" ON "posts" AS PERMISSIVE FOR DELETE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "posts"."author_id"));--> statement-breakpoint
+CREATE POLICY "profiles_select" ON "profiles" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = "profiles"."auth_user_id");--> statement-breakpoint
+CREATE POLICY "profiles_insert" ON "profiles" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = "profiles"."auth_user_id");--> statement-breakpoint
+CREATE POLICY "profiles_update" ON "profiles" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = "profiles"."auth_user_id");--> statement-breakpoint
+CREATE POLICY "stock_tags_select" ON "stock_tags" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = "stock_tags"."stock_id")));--> statement-breakpoint
+CREATE POLICY "stock_tags_insert" ON "stock_tags" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = "stock_tags"."stock_id")));--> statement-breakpoint
+CREATE POLICY "stock_tags_update" ON "stock_tags" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = "stock_tags"."stock_id")));--> statement-breakpoint
+CREATE POLICY "stock_tags_delete" ON "stock_tags" AS PERMISSIVE FOR DELETE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = "stock_tags"."stock_id")));--> statement-breakpoint
+CREATE POLICY "stocks_select" ON "stocks" AS PERMISSIVE FOR SELECT TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "stocks"."author_id"));--> statement-breakpoint
+CREATE POLICY "stocks_insert" ON "stocks" AS PERMISSIVE FOR INSERT TO public WITH CHECK (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "stocks"."author_id"));--> statement-breakpoint
+CREATE POLICY "stocks_update" ON "stocks" AS PERMISSIVE FOR UPDATE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "stocks"."author_id"));--> statement-breakpoint
+CREATE POLICY "stocks_delete" ON "stocks" AS PERMISSIVE FOR DELETE TO public USING (auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = "stocks"."author_id"));

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,685 @@
+{
+  "id": "db8885c1-8ae0-437d-88de-5f930fa0f60b",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channels_author_id_profiles_id_fk": {
+          "name": "channels_author_id_profiles_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "channels_select": {
+          "name": "channels_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"channels\".\"author_id\")"
+        },
+        "channels_insert": {
+          "name": "channels_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"channels\".\"author_id\")"
+        },
+        "channels_update": {
+          "name": "channels_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"channels\".\"author_id\")"
+        },
+        "channels_delete": {
+          "name": "channels_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"channels\".\"author_id\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.post_replies": {
+      "name": "post_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_replies_post_id_posts_id_fk": {
+          "name": "post_replies_post_id_posts_id_fk",
+          "tableFrom": "post_replies",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_replies_author_id_profiles_id_fk": {
+          "name": "post_replies_author_id_profiles_id_fk",
+          "tableFrom": "post_replies",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "post_replies_select": {
+          "name": "post_replies_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"post_replies\".\"author_id\")"
+        },
+        "post_replies_insert": {
+          "name": "post_replies_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"post_replies\".\"author_id\")"
+        },
+        "post_replies_update": {
+          "name": "post_replies_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"post_replies\".\"author_id\")"
+        },
+        "post_replies_delete": {
+          "name": "post_replies_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"post_replies\".\"author_id\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_promoted": {
+          "name": "is_promoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_channel_id_channels_id_fk": {
+          "name": "posts_channel_id_channels_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_profiles_id_fk": {
+          "name": "posts_author_id_profiles_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "posts_select": {
+          "name": "posts_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"posts\".\"author_id\")"
+        },
+        "posts_insert": {
+          "name": "posts_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"posts\".\"author_id\")"
+        },
+        "posts_update": {
+          "name": "posts_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"posts\".\"author_id\")"
+        },
+        "posts_delete": {
+          "name": "posts_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"posts\".\"author_id\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'User'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_auth_user_id_unique": {
+          "name": "profiles_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {
+        "profiles_select": {
+          "name": "profiles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = \"profiles\".\"auth_user_id\""
+        },
+        "profiles_insert": {
+          "name": "profiles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = \"profiles\".\"auth_user_id\""
+        },
+        "profiles_update": {
+          "name": "profiles_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = \"profiles\".\"auth_user_id\""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stock_tags": {
+      "name": "stock_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stock_id": {
+          "name": "stock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stock_tags_stock_id_stocks_id_fk": {
+          "name": "stock_tags_stock_id_stocks_id_fk",
+          "tableFrom": "stock_tags",
+          "tableTo": "stocks",
+          "columnsFrom": [
+            "stock_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_tags_stock_id_tag_unique": {
+          "name": "stock_tags_stock_id_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stock_id",
+            "tag"
+          ]
+        }
+      },
+      "policies": {
+        "stock_tags_select": {
+          "name": "stock_tags_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = \"stock_tags\".\"stock_id\"))"
+        },
+        "stock_tags_insert": {
+          "name": "stock_tags_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = \"stock_tags\".\"stock_id\"))"
+        },
+        "stock_tags_update": {
+          "name": "stock_tags_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = \"stock_tags\".\"stock_id\"))"
+        },
+        "stock_tags_delete": {
+          "name": "stock_tags_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = (SELECT author_id FROM stocks WHERE id = \"stock_tags\".\"stock_id\"))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stocks": {
+      "name": "stocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_post_ids": {
+          "name": "source_post_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "source_channel_id": {
+          "name": "source_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stocks_source_channel_id_channels_id_fk": {
+          "name": "stocks_source_channel_id_channels_id_fk",
+          "tableFrom": "stocks",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "source_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stocks_author_id_profiles_id_fk": {
+          "name": "stocks_author_id_profiles_id_fk",
+          "tableFrom": "stocks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "stocks_select": {
+          "name": "stocks_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"stocks\".\"author_id\")"
+        },
+        "stocks_insert": {
+          "name": "stocks_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "public"
+          ],
+          "withCheck": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"stocks\".\"author_id\")"
+        },
+        "stocks_update": {
+          "name": "stocks_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"stocks\".\"author_id\")"
+        },
+        "stocks_delete": {
+          "name": "stocks_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "public"
+          ],
+          "using": "auth.uid() = (SELECT auth_user_id FROM profiles WHERE id = \"stocks\".\"author_id\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773751898957,
+      "tag": "0000_furry_toro",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,39 +1,38 @@
 "use client";
 
-import { useSyncExternalStore, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-function subscribe() {
-  return () => {};
+function subscribeToTheme(callback: () => void) {
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeSnapshot() {
+  return document.documentElement.classList.contains("dark");
+}
+
+function getServerSnapshot() {
+  return false;
 }
 
 export function ThemeToggle() {
-  const mounted = useSyncExternalStore(
-    subscribe,
-    () => true,
-    () => false,
-  );
-  const [dark, setDark] = useState(() =>
-    typeof document !== "undefined"
-      ? document.documentElement.classList.contains("dark")
-      : false,
+  const dark = useSyncExternalStore(
+    subscribeToTheme,
+    getThemeSnapshot,
+    getServerSnapshot,
   );
 
-  function toggle() {
+  const toggle = useCallback(() => {
     const next = !dark;
-    setDark(next);
     document.documentElement.classList.toggle("dark", next);
     localStorage.setItem("theme", next ? "dark" : "light");
-  }
-
-  if (!mounted) {
-    return (
-      <Button variant="ghost" size="icon" className="h-8 w-8" disabled>
-        <Sun className="h-4 w-4" />
-      </Button>
-    );
-  }
+  }, [dark]);
 
   return (
     <Button


### PR DESCRIPTION
## Summary
- Stock/Note 設計ドキュメント（PLAN.md, REQUIREMENTS.md 等）を .claude/works/ に追加
- drizzle-kit generate で生成したマイグレーション SQL を追加
- dark/light テーマが再起動時にリセットされる問題を修正（useSyncExternalStore + MutationObserver）

## Test plan
- [ ] dark モードに切り替えてページをリロードしても保持されること
- [ ] light モードに切り替えてページをリロードしても保持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)